### PR TITLE
Improve masking performance.

### DIFF
--- a/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/CubismCG.cginc
+++ b/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/CubismCG.cginc
@@ -15,10 +15,7 @@
 
 inline float4 CubismGetMaskChannel(float4 tile)
 {
-	return fixed4(1, 0, 0, 0) * step(0, tile.x) * (1 - step(1, tile.x))
-		+ fixed4(0, 1, 0, 0) * step(1, tile.x) * (1 - step(2, tile.x))
-		+ fixed4(0, 0, 1, 0) * step(2, tile.x) * (1 - step(3, tile.x))
-		+ fixed4(0, 0, 0, 1) * step(3, tile.x);
+	return tile.xxxx == float4(0, 1, 2, 3);
 }
 
 inline float4 CubismGetClippedMaskChannel(float4 coordinates, float4 tile)

--- a/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/CubismCG.cginc
+++ b/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/CubismCG.cginc
@@ -70,7 +70,7 @@ inline float4 CubismToMaskClipPos(float4 vertex, float4 tile, float4 transform)
 }
 
 
-inline float4 CubismSampleMaskTexture(sampler2D tex, float4 channel, float4 coordinates)
+inline float CubismSampleMaskTexture(sampler2D tex, float4 channel, float4 coordinates)
 {
 	float4 texel = tex2D(tex, coordinates.xy) * channel;
 

--- a/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/Mask.shader
+++ b/Assets/Live2D/Cubism/Components/Resources/Live2D/Cubism/Shaders/Mask.shader
@@ -80,7 +80,7 @@ Shader "Live2D Cubism/Mask"
 			sampler2D _MainTex;
 
 
-			fixed4 frag(v2f IN) : COLOR
+			fixed4 frag(v2f IN) : SV_Target
 			{
 				return CUBISM_MASK_CHANNEL * tex2D(_MainTex, IN.texcoord).a;
 


### PR DESCRIPTION
Just compare (i.e. branching has gone! Yeah!) instead of `step` (often, it is expanded to conditional) and multiply element by element.