### PR TITLE
Physics Behaviour mismatch between Cubism Editor and Unity SDK

### DIFF
--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsMath.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsMath.cs
@@ -127,6 +127,7 @@ namespace Live2D.Cubism.Framework.Physics
             var result = 0.0f;
             var maximumValue = Mathf.Max(parameter.MaximumValue, parameter.MinimumValue);
             var minimumValue = Mathf.Min(parameter.MaximumValue, parameter.MinimumValue);
+            var defaultValue = (parameter.MaximumValue + parameter.MinimumValue) / 2;
             var parameterValue = parameter.Value - defaultValue;
 
 
@@ -150,6 +151,7 @@ namespace Live2D.Cubism.Framework.Physics
                         }
 
 
+                        result = NormalizedDefault + parameterValue * Mathf.Abs(normalizedRange / parameterRange);
                     }
                     break;
                 case -1:
@@ -170,6 +172,7 @@ namespace Live2D.Cubism.Framework.Physics
                         }
 
 
+                        result = NormalizedDefault + parameterValue * Mathf.Abs(normalizedRange / parameterRange);
                     }
                     break;
                 case 0:

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsMath.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsMath.cs
@@ -127,7 +127,6 @@ namespace Live2D.Cubism.Framework.Physics
             var result = 0.0f;
             var maximumValue = Mathf.Max(parameter.MaximumValue, parameter.MinimumValue);
             var minimumValue = Mathf.Min(parameter.MaximumValue, parameter.MinimumValue);
-            var defaultValue = parameter.DefaultValue;
             var parameterValue = parameter.Value - defaultValue;
 
 
@@ -151,7 +150,6 @@ namespace Live2D.Cubism.Framework.Physics
                         }
 
 
-                        result = parameter.Value * Mathf.Abs(normalizedRange / parameterRange);
                     }
                     break;
                 case -1:
@@ -172,7 +170,6 @@ namespace Live2D.Cubism.Framework.Physics
                         }
 
 
-                        result = parameter.Value * Mathf.Abs(normalizedRange / parameterRange);
                     }
                     break;
                 case 0:


### PR DESCRIPTION
I've noticed some of my models behave differently when loading them in Unity compared to how they look in the Cubism Physics editor.
I believe this is because the SDK handles parameter normalization differently. The Cubism physics editor seems to use the mean of the maximum and minimum parameter value as center for the input and the SDK uses the default value as center. The attached fix seems to correct this behaviour.

Let me know if you need a sample model to illustrate this.
