### PR TITLE
Fix preview AnimationWindow

### DIFF
--- a/Assets/Live2D/Cubism/Core/CubismModel.cs
+++ b/Assets/Live2D/Cubism/Core/CubismModel.cs
@@ -304,8 +304,16 @@ namespace Live2D.Cubism.Core
             }
 
 
+#if !UNITY_EDITOR
             // Sync parameters back.
             TaskableModel.TryReadParameters(Parameters);
+#else
+            if (Application.isPlaying)
+            {
+                // Sync parameters back.
+                TaskableModel.TryReadParameters(Parameters);
+            }
+#endif
 
 
             // Trigger event.


### PR DESCRIPTION
お世話になっております。
[UnityのAnimationウィンドウでLive2Dで作成したアニメーションのプレビューできない](https://forum.live2d.com/discussion/1261/unity%E3%81%AEanimation%E3%82%A6%E3%82%A3%E3%83%B3%E3%83%89%E3%82%A6%E3%81%A7live2d%E3%81%A7%E4%BD%9C%E6%88%90%E3%81%97%E3%81%9F%E3%82%A2%E3%83%8B%E3%83%A1%E3%83%BC%E3%82%B7%E3%83%A7%E3%83%B3%E3%81%AE%E3%83%97%E3%83%AC%E3%83%93%E3%83%A5%E3%83%BC%E3%81%A7%E3%81%8D%E3%81%AA%E3%81%84)
上記の投稿に対応した修正をさせていただきました、一時的な修正処理になっており恐縮ですが何卒よろしくお願いいたします。
下記のリンクに現象のgif画像と確認した実行環境をまとめております。
[【Unity】Live2DモデルをAnimationウィンドウで編集したいとき](https://qiita.com/tomori_hikage/items/12b0f54d810f56d233b3)