### PR TITLE
Due to no changes CubismUpdateController to add new type Controllers

### DIFF
--- a/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
@@ -74,6 +74,11 @@ namespace Live2D.Cubism.Framework
             // Get cubism update controller.
             _hasUpdateController = (GetComponent<CubismUpdateController>() != null);
         }
+        
+        /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 400;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
@@ -76,6 +76,11 @@ namespace Live2D.Cubism.Framework
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismEyeBlinkController.cs
@@ -78,7 +78,7 @@ namespace Live2D.Cubism.Framework
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 400;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismEyeBlinkController;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
@@ -16,6 +16,7 @@ using Live2D.Cubism.Framework.LookAt;
 using Live2D.Cubism.Rendering;
 using Live2D.Cubism.Rendering.Masking;
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 
@@ -52,7 +53,10 @@ namespace Live2D.Cubism.Framework
 
             // Set delegate.
             var components = model.GetComponents<ICubismUpdatable>();
-            foreach(var component in components)
+            var sortedComponents = new List<ICubismUpdatable>(components);
+            sortedComponents.Sort(CompareByExecutionOrder);
+            
+            foreach(var component in sortedComponents)
             {
 #if UNITY_EDITOR                
                 if (!Application.isPlaying && !component.NeedsUpdateOnEditing)
@@ -74,6 +78,10 @@ namespace Live2D.Cubism.Framework
 #endif
         }
 
+        private static int CompareByExecutionOrder(ICubismUpdatable a, ICubismUpdatable b)
+        {
+            return a.ExecutionOrder - b.ExecutionOrder;
+        }
 
         #region Unity Event Handling
 

--- a/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
@@ -50,128 +50,28 @@ namespace Live2D.Cubism.Framework
             // Clear delegate.
             Delegate.RemoveAll(OnLateUpdate, null);
 
-            ICubismUpdatable renderController = null;
-            ICubismUpdatable maskController = null;
-            ICubismUpdatable fadeController = null;
-            ICubismUpdatable poseController = null;
-            ICubismUpdatable expressionController = null;
-            ICubismUpdatable eyeBlinkController = null;
-            ICubismUpdatable mouthController = null;
-            ICubismUpdatable harmonicMotionController = null;
-            ICubismUpdatable lookController = null;
-
-            // Find cubism components.
+            // Set delegate.
             var components = model.GetComponents<ICubismUpdatable>();
             foreach(var component in components)
             {
-                if (component.GetType() == typeof(CubismRenderController))
-                {
-                    renderController = component;
-                }
-                else if (component.GetType() == typeof(CubismMaskController))
-                {
-                    maskController = component;
-                }
-#if UNITY_EDITOR
-                else if (!Application.isPlaying)
+#if UNITY_EDITOR                
+                if (!Application.isPlaying && !component.NeedsUpdateOnEditing)
                 {
                     continue;
                 }
 #endif
-                else if (component.GetType() == typeof(CubismFadeController))
-                {
-                    fadeController = component;
-                }
-                else if (component.GetType() == typeof(CubismPoseController))
-                {
-                    poseController = component;
-                }
-                else if (component.GetType() == typeof(CubismExpressionController))
-                {
-                    expressionController = component;
-                }
-                else if (component.GetType() == typeof(CubismEyeBlinkController))
-                {
-                    eyeBlinkController = component;
-                }
-                else if (component.GetType() == typeof(CubismMouthController))
-                {
-                    mouthController = component;
-                }
-                else if (component.GetType() == typeof(CubismHarmonicMotionController))
-                {
-                    harmonicMotionController = component;
-                }
-                else if(component.GetType() == typeof(CubismLookController))
-                {
-                    lookController = component;
-                }
+                
+                OnLateUpdate += component.OnLateUpdate;
             }
 
 #if UNITY_EDITOR
-            // Application is playing.
-            if(Application.isPlaying)
+            if (Application.isPlaying)
             {
 #endif
-                // Cache parameter save restore.
                 _parameterStore = model.GetComponent<CubismParameterStore>();
-
-                // Add fade controller late update.
-                if (fadeController != null)
-                {
-                    OnLateUpdate += fadeController.OnLateUpdate;
-                }
-
-                // Add pose controller late update.
-                if (poseController != null)
-                {
-                    OnLateUpdate += poseController.OnLateUpdate;
-                }
-
-                // Add expression controller late update.
-                if (expressionController != null)
-                {
-                    OnLateUpdate += expressionController.OnLateUpdate;
-                }
-
-                // Add eye blink controller late update.
-                if (eyeBlinkController != null)
-                {
-                    OnLateUpdate += eyeBlinkController.OnLateUpdate;
-                }
-
-                // Add mouth controller late update.
-                if (mouthController != null)
-                {
-                    OnLateUpdate += mouthController.OnLateUpdate;
-                }
-
-                // Add harmonic motion controller late update.
-                if (harmonicMotionController != null)
-                {
-                    OnLateUpdate += harmonicMotionController.OnLateUpdate;
-                }
-
-                // Add look controller late update.
-                if (lookController != null)
-                {
-                    OnLateUpdate += lookController.OnLateUpdate;
-                }
 #if UNITY_EDITOR
             }
 #endif
-
-            // Add render late update.
-            if (renderController != null)
-            {
-                OnLateUpdate += renderController.OnLateUpdate;
-            }
-
-            // Add mask controller late update.
-            if (maskController != null)
-            {
-                OnLateUpdate += maskController.OnLateUpdate;
-            }
         }
 
 

--- a/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismUpdateController.cs
@@ -54,7 +54,7 @@ namespace Live2D.Cubism.Framework
             // Set delegate.
             var components = model.GetComponents<ICubismUpdatable>();
             var sortedComponents = new List<ICubismUpdatable>(components);
-            sortedComponents.Sort(CompareByExecutionOrder);
+            CubismUpdateExecutionOrder.SortByExecutionOrder(sortedComponents);
             
             foreach(var component in sortedComponents)
             {
@@ -76,11 +76,6 @@ namespace Live2D.Cubism.Framework
 #if UNITY_EDITOR
             }
 #endif
-        }
-
-        private static int CompareByExecutionOrder(ICubismUpdatable a, ICubismUpdatable b)
-        {
-            return a.ExecutionOrder - b.ExecutionOrder;
         }
 
         #region Unity Event Handling

--- a/Assets/Live2D/Cubism/Framework/CubismUpdateExecutionOrder.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismUpdateExecutionOrder.cs
@@ -1,0 +1,38 @@
+﻿/*
+ * Copyright(c) Live2D Inc. All rights reserved.
+ * 
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at http://live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+using System.Collections.Generic;
+
+
+namespace Live2D.Cubism.Framework
+{
+    /// <summary>
+    /// Cubism update order.
+    /// </summary>
+    public static class CubismUpdateExecutionOrder
+    {
+        public static readonly int CubismFadeController = 100;
+        public static readonly int CubismPoseController = 200;
+        public static readonly int CubismExpressionController = 300;
+        public static readonly int CubismEyeBlinkController = 400;
+        public static readonly int CubismMouthController = 500;
+        public static readonly int CubismHarmonicMotionController = 600;
+        public static readonly int CubismLookController = 700;
+        public static readonly int CubismRenderController = 10000;
+        public static readonly int CubismMaskController = 10100;
+
+        public static void SortByExecutionOrder(List<ICubismUpdatable> updatables)
+        {
+            updatables.Sort(CompareByExecutionOrder);
+        }
+            
+        private static int CompareByExecutionOrder(ICubismUpdatable a, ICubismUpdatable b)
+        {
+            return a.ExecutionOrder - b.ExecutionOrder;
+        }
+    }
+}

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
@@ -97,7 +97,7 @@ namespace Live2D.Cubism.Framework.Expression
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 300;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismExpressionController;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
@@ -93,6 +93,11 @@ namespace Live2D.Cubism.Framework.Expression
             // Add to PlayingExList.
             _playingExpressions.Add(palyingExpression);
         }
+        
+        /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 300;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
@@ -95,6 +95,11 @@ namespace Live2D.Cubism.Framework.Expression
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update manager.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
+++ b/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
@@ -80,7 +80,7 @@ namespace Live2D.Cubism.Framework.HarmonicMotion
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 600;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismHarmonicMotionController;
         
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
+++ b/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
@@ -78,6 +78,11 @@ namespace Live2D.Cubism.Framework.HarmonicMotion
         }
 
         /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 600;
+        
+        /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
         /// </summary>
         public bool NeedsUpdateOnEditing => false;

--- a/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
+++ b/Assets/Live2D/Cubism/Framework/HarmonicMotion/CubismHarmonicMotionController.cs
@@ -78,6 +78,11 @@ namespace Live2D.Cubism.Framework.HarmonicMotion
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Framework/ICubismUpdatable.cs
+++ b/Assets/Live2D/Cubism/Framework/ICubismUpdatable.cs
@@ -12,6 +12,7 @@ namespace Live2D.Cubism.Framework
     /// </summary>
     public interface ICubismUpdatable
     {
+        bool NeedsUpdateOnEditing { get; }
         void OnLateUpdate();
     }
 }

--- a/Assets/Live2D/Cubism/Framework/ICubismUpdatable.cs
+++ b/Assets/Live2D/Cubism/Framework/ICubismUpdatable.cs
@@ -12,6 +12,7 @@ namespace Live2D.Cubism.Framework
     /// </summary>
     public interface ICubismUpdatable
     {
+        int ExecutionOrder { get; }
         bool NeedsUpdateOnEditing { get; }
         void OnLateUpdate();
     }

--- a/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
+++ b/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
@@ -134,6 +134,11 @@ namespace Live2D.Cubism.Framework.LookAt
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
+++ b/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
@@ -134,6 +134,11 @@ namespace Live2D.Cubism.Framework.LookAt
         }
 
         /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 700;
+        
+        /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
         /// </summary>
         public bool NeedsUpdateOnEditing => false;

--- a/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
+++ b/Assets/Live2D/Cubism/Framework/LookAt/CubismLookController.cs
@@ -136,7 +136,7 @@ namespace Live2D.Cubism.Framework.LookAt
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 700;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismLookController;
         
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
@@ -90,6 +90,11 @@ namespace Live2D.Cubism.Framework.MotionFade
         }
 
         /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 100;
+        
+        /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
         /// </summary>
         public bool NeedsUpdateOnEditing => false;

--- a/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
@@ -90,6 +90,11 @@ namespace Live2D.Cubism.Framework.MotionFade
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
         /// <remarks>

--- a/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
@@ -92,7 +92,7 @@ namespace Live2D.Cubism.Framework.MotionFade
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 100;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismFadeController;
         
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
@@ -77,6 +77,11 @@ namespace Live2D.Cubism.Framework.MouthMovement
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
         /// <remarks>

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
@@ -77,6 +77,11 @@ namespace Live2D.Cubism.Framework.MouthMovement
         }
 
         /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 500;
+        
+        /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
         /// </summary>
         public bool NeedsUpdateOnEditing => false;

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
@@ -79,7 +79,7 @@ namespace Live2D.Cubism.Framework.MouthMovement
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 500;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismMouthController;
         
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
+++ b/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
@@ -211,6 +211,11 @@ namespace Live2D.Cubism.Framework.Pose
                 }
             }
         }
+        
+        /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 200;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
+++ b/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
@@ -213,6 +213,11 @@ namespace Live2D.Cubism.Framework.Pose
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => false;
+        
+        /// <summary>
         /// Called by cubism update manager. Updates controller.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
+++ b/Assets/Live2D/Cubism/Framework/Pose/CubismPoseController.cs
@@ -215,7 +215,7 @@ namespace Live2D.Cubism.Framework.Pose
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 200;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismPoseController;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -452,7 +452,7 @@ namespace Live2D.Cubism.Rendering
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 800;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismRenderController;
         
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -450,6 +450,11 @@ namespace Live2D.Cubism.Rendering
         }
 
         /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 800;
+        
+        /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
         /// </summary>
         public bool NeedsUpdateOnEditing => true;

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -450,6 +450,11 @@ namespace Live2D.Cubism.Rendering
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => true;
+        
+        /// <summary>
         /// Called by cubism update controller. Applies billboarding.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -148,6 +148,11 @@ namespace Live2D.Cubism.Rendering.Masking
         }
 
         /// <summary>
+        /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.
+        /// </summary>
+        public bool NeedsUpdateOnEditing => true;
+        
+        /// <summary>
         /// Called by cubism update controller. Updates <see cref="Junktions"/>.
         /// </summary>
         public void OnLateUpdate()

--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -146,6 +146,11 @@ namespace Live2D.Cubism.Rendering.Masking
                     .SetMaskTexture(MaskTexture);
             }
         }
+        
+        /// <summary>
+        /// Called by cubism update controller. Order to invoke OnLateUpdate.
+        /// </summary>
+        public int ExecutionOrder => 900;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.

--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -150,7 +150,7 @@ namespace Live2D.Cubism.Rendering.Masking
         /// <summary>
         /// Called by cubism update controller. Order to invoke OnLateUpdate.
         /// </summary>
-        public int ExecutionOrder => 900;
+        public int ExecutionOrder => CubismUpdateExecutionOrder.CubismMaskController;
 
         /// <summary>
         /// Called by cubism update controller. Needs to invoke OnLateUpdate on Editing.


### PR DESCRIPTION
When we add a new custom Controller, we have to change CubismUpdateController.
Due to no changes CubismUpdateController to add new Controllers.

---

SDK利用者がController を追加したい場合にSDK内のCubismUpdateController の変更が必要になると思いますが、そういった場合でもCubismUpdateControllerの変更なしで行えるように対応しました。