### PR TITLE
Checking bounding box hit every time before checking mesh hit.

### DIFF
--- a/Assets/Live2D/Cubism/Framework/Raycasting/CubismRaycaster.cs
+++ b/Assets/Live2D/Cubism/Framework/Raycasting/CubismRaycaster.cs
@@ -151,6 +151,7 @@ namespace Live2D.Cubism.Framework.Raycasting
                     }
                 }
 
+
                 result[hitCount].Drawable = raycastable.GetComponent<CubismDrawable>();
                 result[hitCount].Distance = distance;
                 result[hitCount].LocalPosition = intersectionInLocalSpace;

--- a/Assets/Live2D/Cubism/Framework/Raycasting/CubismRaycaster.cs
+++ b/Assets/Live2D/Cubism/Framework/Raycasting/CubismRaycaster.cs
@@ -134,27 +134,22 @@ namespace Live2D.Cubism.Framework.Raycasting
                     continue;
                 }
 
+                var bounds = raycastable.Mesh.bounds;
 
-
-                if (raycastablePrecision == CubismRaycastablePrecision.BoundingBox)
+                // Skip non hits (bounding box)
+                if (!bounds.Contains(intersectionInLocalSpace))
                 {
-                    var bounds = raycastable.Mesh.bounds;
-
-                    // Skip non hits
-                    if (!bounds.Contains(intersectionInLocalSpace))
-                    {
-                        continue;
-                    }
+				    continue;
                 }
-                else
+
+                // Do detailed hit-detection against mesh if requested.
+                if (raycastablePrecision == CubismRaycastablePrecision.Triangles)
                 {
-                    // Skip non hits
                     if (!ContainsInTriangles(raycastable.Mesh, intersectionInLocalSpace))
                     {
                         continue;
                     }
                 }
-
 
                 result[hitCount].Drawable = raycastable.GetComponent<CubismDrawable>();
                 result[hitCount].Distance = distance;


### PR DESCRIPTION
This checks if the the intersection is within the bounding box before checking if it is within the mesh even if the _CubismRaycastable_ has _CubismRaycastablePrecision.Triangles_ set as Precision, potentially ruling out _CubismDrawables_ without doing the costly mesh check.

It comes at a small overhead in general, but for my use-case (complex models with many vertices, all Drawables are Raycastable), not having this pre-check with the bounding box lags the application for ~0.5 seconds on mobile every time I raycast the model.