### PR TITLE
hotfix: add missing files

### DIFF
--- a/Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs
+++ b/Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs
@@ -1,0 +1,32 @@
+﻿using System.IO;
+using UnityEditor;
+
+namespace Live2D.Cubism.Editor
+{
+    public class CubismUnityEditorUtility
+    {
+        /// <summary>
+        /// Projectウィンドウで現在選択しているディレクトリのパスを取得。
+        /// Projectウィンドウ以外が選択されていたり、何も選択されていない場合、返す値はAssets直下。
+        /// </summary>
+        /// <returns>Projectウィンドウで現在のディレクトリのパス</returns>
+        public static string GetCurrentDirectoryPath()
+        {
+            var activeObject = Selection.activeObject;
+            var currentDirectoryPath = ((activeObject == null)
+                ? "Assets"
+                : AssetDatabase.GetAssetPath(activeObject.GetInstanceID()));
+
+            if (string.IsNullOrEmpty(currentDirectoryPath))
+            {
+                currentDirectoryPath = "Assets";
+            }
+            else if (!Directory.Exists(currentDirectoryPath))
+            {
+                currentDirectoryPath = currentDirectoryPath.Replace("/" + Path.GetFileName(currentDirectoryPath), "");
+            }
+
+            return currentDirectoryPath;
+        }
+    }
+}

--- a/Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs.meta
+++ b/Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ff8056c5310fdcf42a95603ce5419c41
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat
@@ -1,0 +1,24 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: MaskCulling
+  m_Shader: {fileID: 4800000, guid: b63407b5a5c26f44fb4d9681e9e55f1a, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs: []
+    m_Floats:
+    - _Cull: 1
+    m_Colors: []

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3efcf46cd84d6e946a927b69fb60a102
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitAdditiveCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 1
+    - _SrcAlpha: 0
+    - _SrcColor: 1
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 0
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3de4f8c3e3fcb04891cb3f0289ec3f8
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitAdditiveMaskedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_MASK_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 1
+    - _SrcAlpha: 0
+    - _SrcColor: 1
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 2ec5fe9e6b4e4754c9cf6def40427e17
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitAdditiveMaskedInvertedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_INVERT_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 1
+    - _SrcAlpha: 0
+    - _SrcColor: 1
+    - cubism_InvertOn: 1
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d42c19d7c21ae1340b855c0009c28d89
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 10
+    - _DstColor: 10
+    - _SrcAlpha: 1
+    - _SrcColor: 1
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 0
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 575dc3647e5267947bf62b26350daf11
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitMaskedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_MASK_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 10
+    - _DstColor: 10
+    - _SrcAlpha: 1
+    - _SrcColor: 1
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e29651c08020234a9cfde88dcdeba97
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitMaskedInvertedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_INVERT_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 10
+    - _DstColor: 10
+    - _SrcAlpha: 1
+    - _SrcColor: 1
+    - cubism_InvertOn: 1
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 68337a07fefeaa447b9efae7b9dd61a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitMultiplyCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: 
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 10
+    - _SrcAlpha: 0
+    - _SrcColor: 2
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 0
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: fd405c8114d02f145ab1469a8f855a5c
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitMultiplyMaskedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_MASK_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 10
+    - _SrcAlpha: 0
+    - _SrcColor: 2
+    - cubism_InvertOn: 0
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: d69deb3dd47135640b39c0376dc33ab5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat
@@ -1,0 +1,41 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!21 &2100000
+Material:
+  serializedVersion: 6
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: UnlitMultiplyMaskedInvertedCulling
+  m_Shader: {fileID: 4800000, guid: b6ac6b89a3f2a5d4ba21b017d47b480c, type: 3}
+  m_ShaderKeywords: CUBISM_INVERT_ON
+  m_LightmapFlags: 4
+  m_EnableInstancingVariants: 0
+  m_DoubleSidedGI: 0
+  m_CustomRenderQueue: -1
+  stringTagMap: {}
+  disabledShaderPasses: []
+  m_SavedProperties:
+    serializedVersion: 3
+    m_TexEnvs:
+    - _MainTex:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    - cubism_MaskTexture:
+        m_Texture: {fileID: 0}
+        m_Scale: {x: 1, y: 1}
+        m_Offset: {x: 0, y: 0}
+    m_Floats:
+    - _Cull: 1
+    - _DstAlpha: 1
+    - _DstColor: 10
+    - _SrcAlpha: 0
+    - _SrcColor: 2
+    - cubism_InvertOn: 1
+    - cubism_MaskOn: 1
+    - cubism_ModelOpacity: 1
+    m_Colors:
+    - cubism_MaskTile: {r: 0, g: 0, b: 0, a: 0}
+    - cubism_MaskTransform: {r: 0, g: 0, b: 0, a: 0}

--- a/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat.meta
+++ b/Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8e87e9e3645e9e543b82a95ce6510dcf
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
add missing files for Cubism SDK for Unity R2 update.
NOTICE: These files are included in Cubism SDK for Unity R2 unitypackage.

---
Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs
Assets/Live2D/Cubism/Editor/CubismUnityEditorUtility.cs.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/MaskCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitAdditiveMaskedInvertedCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMaskedInvertedCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedCulling.mat.meta
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat
Assets/Live2D/Cubism/Rendering/Resources/Live2D/Cubism/Materials/UnlitMultiplyMaskedInvertedCulling.mat.meta
