### PR TITLE
Improved import process.

### DIFF
--- a/Assets/Live2D/Cubism/CHANGELOG.md
+++ b/Assets/Live2D/Cubism/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased]
+
+### Added
+
+* Fixed so that even if an error occurs during import, subsequent import processing will continue. [@TakahiroSato](https://github.com/TakahiroSato)
+
 
 ## [4-r.2] - 2021-01-12
 

--- a/Assets/Live2D/Cubism/Editor/CubismAssetProcessor.cs
+++ b/Assets/Live2D/Cubism/Editor/CubismAssetProcessor.cs
@@ -10,6 +10,7 @@ using Live2D.Cubism.Editor.Deleters;
 using Live2D.Cubism.Editor.Importers;
 using Live2D.Cubism.Rendering;
 using Live2D.Cubism.Rendering.Masking;
+using System;
 using System.IO;
 using System.Linq;
 using System.Xml.Linq;
@@ -65,8 +66,15 @@ namespace Live2D.Cubism.Editor
                     continue;
                 }
 
-
-                importer.Import();
+                try
+                {
+                    importer.Import();
+                }
+                catch(Exception e)
+                {
+                    Debug.LogError("CubismAssetProcessor : Following error occurred while importing " + assetPath);
+                    Debug.LogError(e);
+                }
             }
 
 


### PR DESCRIPTION
お世話になっております。

初めてPull requestを送らせて頂きます。
TakahiroSatoと申します。[Live2D コミュニティアカウント](https://forum.live2d.com/profile/TakahiroSato)

今回ですが、UnityへのLive2Dモデルのドラッグ＆ドロップ時のインポート処理へ手を入れさせて頂きました。

内容としては、インポート時に何らかのエラーが有った際（Jsonパースエラー等）、今まではそこでインポート処理が中断されていましたが、それをエラーがあったファイルのパスとExceptionをエラーログに出力後、後続のインポート処理自体は継続させるようにしたというものです。

今回Pull requestを送らせて頂いた経緯としましては、
業務上Live2Dデザイナーさんから複数のLive2Dモデルのインポートをお願いされることが多々あり、
エクスプローラから複数モデルを選択してUnity上へ一括でのインポートを行うことがあるのですが、
その際に、どれか一モデルでもエラーを含んだものがあった際にそのモデル以外の正常なモデルのインポートも中途半端にされた状態（フォルダとファイルだけはUnity上に残るが、Live2DのPrefabが存在しない状態）になり、かつどのモデルでエラーが起こっているのかも分からないという状態が頻発していたためです。
そのため、現状だとどのモデルのどの部分が原因か一体一体インポートして確かめるという手間がかかっておりました。
（エラーの含まれるモデルのインポート処理が走る以前のモデルはPrefab作成までされるのですが、どの順番でされたかがわからず、また一見UnityEditorのフォルダ上では全てのフォルダが存在する状態なので判別が非常に難しいことになっておりました。）

今回の改修で、エラーが含まれるモデルに関しては問題のあるファイルとそのエラー内容の表示がされるようになり、また、その他正常なものについてはインポート処理が正常に行われるようになります（Prefabが作成される）

動作確認は
Unity 2019.4.14f1
で行いました。

お忙しいところ恐縮ですが、ご確認頂けますと幸いです。
よろしくお願い致します。