### PR TITLE
Fixing import of models with invalid masks

### DIFF
--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -8,6 +8,7 @@
 
 using Live2D.Cubism.Core;
 using Live2D.Cubism.Framework;
+using System;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Rendering;

--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -120,7 +120,14 @@ namespace Live2D.Cubism.Rendering.Masking
                 }
 
                 // Make sure no leftover null-entries are added as mask.
-                pairs.Add(drawables[i], Array.FindAll(drawables[i].Masks, mask => mask != null));
+                var masks = Array.FindAll(drawables[i].Masks, mask => mask != null);
+
+                if (masks.Length == 0)
+                {
+                    continue;
+                }
+
+                pairs.Add(drawables[i], masks);
             }
 
 

--- a/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
+++ b/Assets/Live2D/Cubism/Rendering/Masking/CubismMaskController.cs
@@ -118,8 +118,8 @@ namespace Live2D.Cubism.Rendering.Masking
                     continue;
                 }
 
-
-                pairs.Add(drawables[i], drawables[i].Masks);
+                // Make sure no leftover null-entries are added as mask.
+                pairs.Add(drawables[i], Array.FindAll(drawables[i].Masks, mask => mask != null));
             }
 
 


### PR DESCRIPTION
In the Live2D Cubism Editor, when deleting **ArtMesh A** that is used as mask for **ArtMesh B**, this will leave an entry "null" in the list of masks for **ArtMesh B**.

Importing such models using the Live2D Unity SDK will result in various exceptions and all masking functionality being broken.

Ideally, such "null" entries would be automatically removed when exporting from the Live2D Cubism Editor but to support existing models "broken" in that way, it might be a good idea to add a fix like the one proposed in this PR to make sure such models can still be imported without causing issues.