### PR TITLE
Take over physics and blink status to another model.

### DIFF
--- a/Assets/Live2D/Cubism/Core/CubismModelExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Core/CubismModelExtensionMethods.cs
@@ -1,0 +1,45 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+
+using Live2D.Cubism.Framework;
+using Live2D.Cubism.Framework.Physics;
+
+
+namespace Live2D.Cubism.Core
+{
+    /// <summary>
+    /// Extends <see cref="CubismModel"/>s.
+    /// </summary>
+    public static class CubismModelExtensionMethods
+    {
+        /// <summary>
+        /// Transfer physics settings and blink settings from <paramref name="source"/> to <paramref name="destination"/>.
+        /// </summary>
+        /// <remarks>
+        /// Helper method for smooth switching between models when changing clothes, etc.
+        /// The structure of the physics rig needs to be the same for the old and new models.
+        /// </remarks>
+        /// <param name="source">Model to be taken over from</param>
+        /// <param name="destination">Model to be taken over</param>
+        public static void TakeOver(this CubismModel source, CubismModel destination)
+        {
+            if (source == null)
+                throw new System.ArgumentNullException(nameof(source));
+            if (destination == null)
+                throw new System.ArgumentNullException(nameof(destination));
+
+            var physicsSource = source.GetComponent<CubismPhysicsController>();
+            var physicsDestination = destination.GetComponent<CubismPhysicsController>();
+            physicsDestination.Rig.TakeOverFrom(physicsSource.Rig);
+
+            var eyeSource = source.GetComponent<CubismAutoEyeBlinkInput>();
+            var eyeDestination = destination.GetComponent<CubismAutoEyeBlinkInput>();
+            eyeDestination.TakeOverFrom(eyeSource);
+        }
+    }
+}

--- a/Assets/Live2D/Cubism/Core/CubismModelExtensionMethods.cs.meta
+++ b/Assets/Live2D/Cubism/Core/CubismModelExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 07118d892b995cf4e985b4e13400fe60
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Framework/CubismAutoEyeBlinkInput.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismAutoEyeBlinkInput.cs
@@ -64,6 +64,17 @@ namespace Live2D.Cubism.Framework
             T = 0f;
         }
 
+        /// <summary>
+        /// Take over eye blink status.
+        /// </summary>
+        /// <param name="input"></param>
+        public void TakeOverFrom(CubismAutoEyeBlinkInput input)
+        {
+            T = input.T;
+            CurrentPhase = input.CurrentPhase;
+            LastValue = input.LastValue;
+        }
+
         #region Unity Event Handling
 
         /// <summary>

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsController.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsController.cs
@@ -21,10 +21,10 @@ namespace Live2D.Cubism.Framework.Physics
         /// <summary>
         /// Simulation target rig.
         /// </summary>
-        private CubismPhysicsRig Rig
+        public CubismPhysicsRig Rig
         {
             get { return _rig; }
-            set { _rig = value; }
+            private set { _rig = value; }
         }
 
         [SerializeField]

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsRig.cs
@@ -61,5 +61,20 @@ namespace Live2D.Cubism.Framework.Physics
                 SubRigs[i].Evaluate(deltaTime);
             }
         }
+
+        /// <summary>
+        /// Take over physics rig status.
+        /// </summary>
+        /// <remarks>
+        /// The structure of the physics rig needs to be the same for the old and new models.
+        /// </remarks>
+        /// <param name="physicsRig"></param>
+        public void TakeOverFrom(CubismPhysicsRig physicsRig)
+        {
+            for (var i = 0; i < SubRigs.Length; ++i)
+            {
+                SubRigs[i].TakeOverFrom(physicsRig.SubRigs[i]);
+            }
+        }
     }
 }

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
@@ -224,6 +224,20 @@ namespace Live2D.Cubism.Framework.Physics
             }
         }
 
+        /// <summary>
+        /// Take over physics rig status.
+        /// </summary>
+        /// <param name="subRig"></param>
+        public void TakeOverFrom(CubismPhysicsSubRig subRig)
+        {
+            var oldP = subRig.Particles;
+            var strand = Particles;
+
+            for (var i =01; i < strand.Length; ++i)
+            {
+                strand[i] = oldP[i];
+            }
+        }
 
         /// <summary>
         /// Evaluate rig in every frame.


### PR DESCRIPTION
Helper method for smooth switching between models when changing clothes, etc.
(The structure of the physics Rig must be the same for the new and old models)

着替えなどでモデルを切り替える際になめらかに切り替えられるようにする際のヘルパーメソッド
(新旧モデルで物理Rigの構造が同一である必要がある)