### PR TITLE
Make the mouth movement fade when the voice starts and stops.

### DIFF
--- a/Assets/Live2D/Cubism/Framework/CubismParameterExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismParameterExtensionMethods.cs
@@ -75,13 +75,14 @@ namespace Live2D.Cubism.Framework
         /// <param name="self"><see langword="this"/>.</param>
         /// <param name="value">Value to blend in.</param>
         /// <param name="mode">Blend mode to use.</param>
-        public static void BlendToValue(this CubismParameter[] self, CubismParameterBlendMode mode, float value)
+        /// <param name="weight">Blend weight.</param>
+        public static void BlendToValue(this CubismParameter[] self, CubismParameterBlendMode mode, float value, float weight = 1)
         {
             if (mode == CubismParameterBlendMode.Additive)
             {
                 for (var i = 0; i < self.Length; ++i)
                 {
-                    self[i].AddToValue(value);
+                    self[i].AddToValue(value, weight);
                 }
 
 
@@ -93,7 +94,7 @@ namespace Live2D.Cubism.Framework
             {
                 for (var i = 0; i < self.Length; ++i)
                 {
-                    self[i].MultiplyValueBy(value);
+                    self[i].MultiplyValueBy(value, weight);
                 }
 
 
@@ -103,7 +104,7 @@ namespace Live2D.Cubism.Framework
 
             for (var i = 0; i < self.Length; ++i)
             {
-                self[i].Value = value;
+                self[i].Value = self[i].Value * (1 - weight) + value * weight;
             }
         }
     }

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismAudioMouthInput.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismAudioMouthInput.cs
@@ -126,11 +126,11 @@ namespace Live2D.Cubism.Framework.MouthMovement
         private void Update()
         {
             // 'Fail' silently.
-            if (AudioInput == null)
+            if (AudioInput == null || !AudioInput.isPlaying || !Target.enabled)
             {
+                Target.HasInput = false;
                 return;
             }
-
 
             // Sample audio.
             var total = 0f;
@@ -162,6 +162,7 @@ namespace Live2D.Cubism.Framework.MouthMovement
 
             // Set rms as mouth opening and store it for next evaluation.
             Target.MouthOpening = rms;
+            Target.HasInput = true;
 
 
             LastRms = rms;

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismAutoMouthInput.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismAutoMouthInput.cs
@@ -63,7 +63,7 @@ namespace Live2D.Cubism.Framework.MouthMovement
         private void LateUpdate()
         {
             // Fail silently.
-            if (Controller == null)
+            if (Controller == null || !Controller.enabled)
             {
                 return;
             }
@@ -75,6 +75,7 @@ namespace Live2D.Cubism.Framework.MouthMovement
 
             // Evaluate.
             Controller.MouthOpening = Mathf.Abs(Mathf.Sin(T));
+            Controller.HasInput = true;
         }
 
         #endregion

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
@@ -30,6 +30,16 @@ namespace Live2D.Cubism.Framework.MouthMovement
         [SerializeField, Range(0f, 1f)]
         public float MouthOpening = 1f;
 
+        /// <summary>
+        /// It has voice input.
+        /// </summary>
+        public bool HasInput { get; set; }
+
+        /// <summary>
+        /// Apply to CubismMouthParameter or.
+        /// </summary>
+        [SerializeField]
+        public bool CanOutput = true;
 
         /// <summary>
         /// Mouth parameters.
@@ -102,6 +112,10 @@ namespace Live2D.Cubism.Framework.MouthMovement
         public void OnLateUpdate()
         {
             // Fail silently.
+            if (!HasInput || !CanOutput)
+            {
+                return;
+            }
             if (!enabled || Destinations == null)
             {
                 return;

--- a/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
+++ b/Assets/Live2D/Cubism/Framework/MouthMovement/CubismMouthController.cs
@@ -42,6 +42,12 @@ namespace Live2D.Cubism.Framework.MouthMovement
         public bool CanOutput = true;
 
         /// <summary>
+        /// Fade when switching between <see cref="HasInput"/> on / off
+        /// </summary>
+        [SerializeField]
+        public bool HasFade = true;
+
+        /// <summary>
         /// Mouth parameters.
         /// </summary>
         private CubismParameter[] Destinations { get; set; }
@@ -103,6 +109,8 @@ namespace Live2D.Cubism.Framework.MouthMovement
             get { return false; }
         }
 
+        private float _fadeWeight = 0;
+
         /// <summary>
         /// Called by cubism update controller. Updates controller.
         /// </summary>
@@ -111,19 +119,27 @@ namespace Live2D.Cubism.Framework.MouthMovement
         /// </remarks>
         public void OnLateUpdate()
         {
-            // Fail silently.
             if (!HasInput || !CanOutput)
             {
-                return;
+                if (0 < _fadeWeight)
+                    _fadeWeight -= 0.1f;
+                if (!HasFade || _fadeWeight < 0)
+                    _fadeWeight = 0;
             }
-            if (!enabled || Destinations == null)
+            else
             {
-                return;
+                if (_fadeWeight < 1)
+                    _fadeWeight += 0.05f;
+                if (!HasFade || 1 < _fadeWeight)
+                    _fadeWeight = 1;
             }
 
+            // Fail silently.
+            if (!enabled || Destinations == null || _fadeWeight <= 0)
+                return;
 
             // Apply value.
-            Destinations.BlendToValue(BlendMode, MouthOpening);
+            Destinations.BlendToValue(BlendMode, MouthOpening, _fadeWeight);
         }
 
         #region Unity Events Handling


### PR DESCRIPTION
It was uncomfortable to suddenly change the shape of the mouth when starting or stopping voice playback, so it is now possible to select whether or not to have the mouth change shape smoothly by fading.

ボイスの再生開始時や停止時に、急に口の形が変わるのは違和感があったので、フェードでスムーズに口の形が変わるようにするかどうかを選択できるようにしました。