### PR TITLE
Add cubism physics extension methods

### DIFF
--- a/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
@@ -29,5 +29,29 @@ namespace Live2D.Cubism.Framework.Physics
 
             return controller.Rig.GetSubRig(name);
         }
+
+
+        /// <summary>
+        /// Set <see cref="CubismPhysicsOutput.AngleScale"/> to the ratio by the argument to the original value.
+        /// </summary>
+        /// <param name="subRig"></param>
+        /// <param name="ratio">Ratio to original value</param>
+        /// <param name="predicate">If null, all <see cref="CubismPhysicsSubRig.Output"/> are targeted</param>
+        public static void SetPhysicsSubRigOutputAngleScaleRatio(this CubismPhysicsSubRig subRig, float ratio, Func<CubismPhysicsOutput, bool> predicate = null)
+        {
+            if (subRig == null)
+                return;
+
+            for (int i = 0; i < subRig.Output.Length; i++)
+            {
+                if (!(predicate?.Invoke(subRig.Output[i]) ?? true))
+                    continue;
+
+                var original = subRig.OriginalOutput[i];
+
+                subRig.Output[i].AngleScale = Math.Max(original.AngleScale * ratio, 0);
+                subRig.Output[i].InitializeGetter();
+            }
+        }
     }
 }

--- a/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
@@ -53,5 +53,29 @@ namespace Live2D.Cubism.Framework.Physics
                 subRig.Output[i].InitializeGetter();
             }
         }
+
+
+        /// <summary>
+        /// Set <see cref="CubismPhysicsOutput.IsInverted"/> whether or not to invert for the original bool value.
+        /// </summary>
+        /// <param name="subRig"></param>
+        /// <param name="isInvert">Invert the original bool value</param>
+        /// <param name="predicate">If null, all <see cref="CubismPhysicsSubRig.Output"/> are targeted</param>
+        public static void SetPhysicsSubRigOutputIsInverted(this CubismPhysicsSubRig subRig, bool isInvert, Func<CubismPhysicsOutput, bool> predicate = null)
+        {
+            if (subRig == null)
+                return;
+
+            for (int i = 0; i < subRig.Output.Length; i++)
+            {
+                if (!(predicate?.Invoke(subRig.Output[i]) ?? true))
+                    continue;
+
+                var original = subRig.OriginalOutput[i];
+
+                subRig.Output[i].IsInverted = isInvert ? !original.IsInverted : original.IsInverted;
+                subRig.Output[i].InitializeGetter();
+            }
+        }
     }
 }

--- a/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs
@@ -1,0 +1,33 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+
+using Live2D.Cubism.Core;
+using System;
+
+namespace Live2D.Cubism.Framework.Physics
+{
+    /// <summary>
+    /// Extensions for <see cref="CubismPhysics"/>s.
+    /// </summary>
+    public static class CubismPhysicsExtensionMethods
+    {
+        /// <summary>
+        /// Get <see cref="CubismPhysicsSubRig"/> by name.
+        /// </summary>
+        /// <param name="cubismModel"></param>
+        /// <param name="name">sub rig name</param>
+        public static CubismPhysicsSubRig GetPhysicsSubRig(this CubismModel cubismModel, string name)
+        {
+            var controller = cubismModel.GetComponent<CubismPhysicsController>();
+            if (controller == null)
+                return null;
+
+            return controller.Rig.GetSubRig(name);
+        }
+    }
+}

--- a/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs.meta
+++ b/Assets/Live2D/Cubism/Framework/CubismPhysicsExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: c396306236c388c49ae7dfdf5108951f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Framework/Json/CubismPhysics3Json.cs
+++ b/Assets/Live2D/Cubism/Framework/Json/CubismPhysics3Json.cs
@@ -8,6 +8,7 @@
 
 using Live2D.Cubism.Framework.Physics;
 using System;
+using System.Linq;
 using UnityEngine;
 
 
@@ -54,11 +55,13 @@ namespace Live2D.Cubism.Framework.Json
 
             instance.SubRigs = new CubismPhysicsSubRig[Meta.PhysicsSettingCount];
 
+            var idNameTable = Meta.PhysicsDictionary.ToDictionary(x => x.Id, x => x.Name);
 
             for (var i = 0; i < instance.SubRigs.Length; ++i)
             {
                 instance.SubRigs[i] = new CubismPhysicsSubRig
                 {
+                    Name          = idNameTable[PhysicsSettings[i].Id],
                     Input         = ReadInput(PhysicsSettings[i].Input),
                     Output        = ReadOutput(PhysicsSettings[i].Output),
                     Particles     = ReadParticles(PhysicsSettings[i].Vertices),
@@ -391,13 +394,33 @@ namespace Live2D.Cubism.Framework.Json
 
 
         /// <summary>
+        /// Physics Id - Name Table Item.
+        /// </summary>
+        [Serializable]
+        public struct PhysicsDictionaryItem
+        {
+            /// <summary>
+            /// ID for internal management.
+            /// </summary>
+            [SerializeField]
+            public string Id;
+
+            /// <summary>
+            /// Physics Setting Name.
+            /// </summary>
+            [SerializeField]
+            public string Name;
+        }
+
+
+        /// <summary>
         /// Setting of physics calculation.
         /// </summary>
         [Serializable]
         public struct SerializablePhysicsSettings
         {
             /// <summary>
-            /// TODO Document.
+            /// ID for internal management.
             /// </summary>
             [SerializeField]
             public string Id;
@@ -463,6 +486,12 @@ namespace Live2D.Cubism.Framework.Json
             /// </summary>
             [SerializeField]
             public SerializableEffectiveForces EffectiveForces;
+
+            /// <summary>
+            /// Physics Id - Name Table
+            /// </summary>
+            [SerializeField]
+            public PhysicsDictionaryItem[] PhysicsDictionary;
         }
 
 

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsRig.cs
@@ -7,6 +7,7 @@
 
 
 using System;
+using System.Collections.Generic;
 using UnityEngine;
 
 
@@ -38,15 +39,30 @@ namespace Live2D.Cubism.Framework.Physics
         /// </summary>
         public CubismPhysicsController Controller { get; set; }
 
+        private Dictionary<string, CubismPhysicsSubRig> _subRigNameTable;
+
+        /// <summary>
+        /// Get <see cref="CubismPhysicsSubRig"/> by name
+        /// </summary>
+        /// <param name="name"></param>
+        /// <returns></returns>
+        public CubismPhysicsSubRig GetSubRig(string name) => _subRigNameTable.TryGetValue(name, out var subRig) ? subRig : null;
 
         /// <summary>
         /// Initializes rigs.
         /// </summary>
         public void Initialize()
         {
+            if (_subRigNameTable == null)
+                _subRigNameTable = new Dictionary<string,CubismPhysicsSubRig>();
+            else
+                _subRigNameTable.Clear();
+
             for (var i = 0; i < SubRigs.Length; ++i)
             {
-                SubRigs[i].Initialize();
+                var subRig = SubRigs[i];
+                subRig.Initialize();
+                _subRigNameTable[subRig.Name] = subRig;
             }
         }
 

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
@@ -32,10 +32,22 @@ namespace Live2D.Cubism.Framework.Physics
         public CubismPhysicsInput[] Input;
 
         /// <summary>
+        /// Original Input.
+        /// </summary>
+        [NonSerialized]
+        public CubismPhysicsInput[] OriginalInput;
+
+        /// <summary>
         /// Output.
         /// </summary>
         [SerializeField]
         public CubismPhysicsOutput[] Output;
+
+        /// <summary>
+        /// Original Output.
+        /// </summary>
+        [NonSerialized]
+        public CubismPhysicsOutput[] OriginalOutput;
 
         /// <summary>
         /// Particles.
@@ -100,6 +112,7 @@ namespace Live2D.Cubism.Framework.Physics
 
 
             var weight = (output.Weight / CubismPhysics.MaximumWeight);
+
 
             if (weight >= 1.0f)
             {
@@ -218,14 +231,18 @@ namespace Live2D.Cubism.Framework.Physics
 
 
             // Initialize inputs.
+            OriginalInput = new CubismPhysicsInput[Input.Length];
             for (var i = 0; i < Input.Length; ++i)
             {
+                OriginalInput[i] = Input[i];
                 Input[i].InitializeGetter();
             }
 
             // Initialize outputs.
+            OriginalOutput = new CubismPhysicsOutput[Output.Length];
             for (var i = 0; i < Output.Length; ++i)
             {
+                OriginalOutput[i] = Output[i];
                 Output[i].InitializeGetter();
             }
         }

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
@@ -20,6 +20,12 @@ namespace Live2D.Cubism.Framework.Physics
     public class CubismPhysicsSubRig
     {
         /// <summary>
+        /// Name.
+        /// </summary>
+        [SerializeField]
+        public string Name;
+
+        /// <summary>
         /// Input.
         /// </summary>
         [SerializeField]


### PR DESCRIPTION
The name of the physical setting can now be seen on the Unity inspector.
![physicsnameininspector](https://user-images.githubusercontent.com/781133/171212195-60b28b29-8e57-4993-bc76-76772e70437f.jpg)

By using this extensions methods, the application can implement the function to switch the direction of head and body movement, as shown in the following video, without having to prepare the parameters for the direction of movement on the Live2D side.

https://youtu.be/0AOATlsMQig?t=146
