### PR TITLE
Refact and tuning

### DIFF
--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsInput.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsInput.cs
@@ -189,6 +189,12 @@ namespace Live2D.Cubism.Framework.Physics
         public CubismParameter Source;
 
         /// <summary>
+        /// <see cref="Source"/> index.
+        /// </summary>
+        [NonSerialized]
+        public int SourceIndex;
+
+        /// <summary>
         /// Function of getting normalized parameter value.
         /// </summary>
         [NonSerialized]

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsOutput.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsOutput.cs
@@ -261,6 +261,12 @@ namespace Live2D.Cubism.Framework.Physics
         public CubismParameter Destination;
 
         /// <summary>
+        /// <see cref="Destination"/> index.
+        /// </summary>
+        [NonSerialized]
+        public int DestinationIndex;
+
+        /// <summary>
         /// Function of getting output value.
         /// </summary>
         [NonSerialized]

--- a/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
+++ b/Assets/Live2D/Cubism/Framework/Physics/CubismPhysicsSubRig.cs
@@ -351,20 +351,21 @@ namespace Live2D.Cubism.Framework.Physics
 
             for (var i = 0; i < Input.Length; ++i)
             {
-                var weight = Input[i].Weight / CubismPhysics.MaximumWeight;
+                ref var input = ref Input[i];
+                var weight = input.Weight / CubismPhysics.MaximumWeight;
 
-                if (Input[i].Source == null)
+                if (input.Source == null)
                 {
-                    Input[i].Source = Rig.Controller.Parameters.FindById(Input[i].SourceId);
+                    input.Source = Rig.Controller.Parameters.FindById(input.SourceId);
+                    input.SourceIndex = Array.IndexOf(Rig.Controller.Parameters, input.Source);
                 }
-                var index = Array.IndexOf(Rig.Controller.Parameters, Input[i].Source);
 
-                var parameter = Input[i].Source;
-                Input[i].GetNormalizedParameterValue(
+                var parameter = input.Source;
+                input.GetNormalizedParameterValue(
                     ref totalTranslation,
                     ref totalAngle,
                     parameter,
-                    ref Rig.ParametersCache[index],
+                    ref Rig.ParametersCache[input.SourceIndex],
                     Normalization,
                     weight
                     );
@@ -390,42 +391,44 @@ namespace Live2D.Cubism.Framework.Physics
 
             for (var i = 0; i < Output.Length; ++i)
             {
-                _previousRigOutput.Output[i] = _currentRigOutput.Output[i];
+                ref var currentRigOutput = ref _currentRigOutput.Output[i];
+                _previousRigOutput.Output[i] = currentRigOutput;
 
-                if (Output[i].Destination == null)
+                ref var output = ref Output[i];
+
+                if (output.Destination == null)
                 {
-                    var destination = Rig.Controller.Parameters.FindById(Output[i].DestinationId);
+                    var destination = Rig.Controller.Parameters.FindById(output.DestinationId);
                     if (destination == null)
                     {
                         continue;
                     }
 
-                    Output[i].Destination = destination;
+                    output.Destination = destination;
+                    output.DestinationIndex = Array.IndexOf(Rig.Controller.Parameters, output.Destination);
                 }
 
-                var particleIndex = Output[i].ParticleIndex;
+                var particleIndex = output.ParticleIndex;
 
                 if (particleIndex < 1 || particleIndex >= Particles.Length)
                 {
                     continue;
                 }
 
-                var index = Array.IndexOf(Rig.Controller.Parameters, Output[i].Destination);
-
                 var translation = Particles[particleIndex].Position -
                                         Particles[particleIndex - 1].Position;
 
-                var parameter = Output[i].Destination;
-                var outputValue = Output[i].GetValue(
+                var parameter = output.Destination;
+                var outputValue = output.GetValue(
                     translation,
                     Particles,
                     particleIndex,
                     Rig.Gravity
                     );
 
-                _currentRigOutput.Output[i] = outputValue;
+                currentRigOutput = outputValue;
 
-                UpdateOutputParameterValue(parameter, ref Rig.ParametersCache[index], outputValue, Output[i]);
+                UpdateOutputParameterValue(parameter, ref Rig.ParametersCache[output.DestinationIndex], outputValue, output);
             }
         }
 

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -479,17 +479,6 @@ namespace Live2D.Cubism.Rendering
         private CubismRenderer[] _renderers;
 
         /// <summary>
-        /// multiply color buffer.
-        /// </summary>
-        private Color[] _newMultiplyColors;
-
-        /// <summary>
-        /// screen color buffer.
-        /// </summary>
-        private Color[] _newScreenColors;
-
-
-        /// <summary>
         /// <see cref="CubismRenderer"/>s.
         /// </summary>
         public CubismRenderer[] Renderers
@@ -505,6 +494,17 @@ namespace Live2D.Cubism.Rendering
             }
             private set { _renderers = value; }
         }
+
+
+        /// <summary>
+        /// multiply color buffer.
+        /// </summary>
+        private Color[] _newMultiplyColors;
+
+        /// <summary>
+        /// screen color buffer.
+        /// </summary>
+        private Color[] _newScreenColors;
 
 
         /// <summary>

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -610,8 +610,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
-            _newMultiplyColors ??= new Color[_renderers.Length];
-            _newScreenColors ??= new Color[_renderers.Length];
+            _newMultiplyColors ??= new Color[Renderers.Length];
+            _newScreenColors ??= new Color[Renderers.Length];
             var newMultiplyColors = _newMultiplyColors;
             var newScreenColors = _newScreenColors;
 
@@ -894,8 +894,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
-            _newMultiplyColors ??= new Color[_renderers.Length];
-            _newScreenColors ??= new Color[_renderers.Length];
+            _newMultiplyColors ??= new Color[Renderers.Length];
+            _newScreenColors ??= new Color[Renderers.Length];
             var newMultiplyColors = _newMultiplyColors;
             var newScreenColors = _newScreenColors;
 

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -499,8 +499,6 @@ namespace Live2D.Cubism.Rendering
                 if (_renderers == null)
                 {
                     _renderers = Model.Drawables.GetComponentsMany<CubismRenderer>();
-                    _newMultiplyColors = new Color[_renderers.Length];
-                    _newScreenColors = new Color[_renderers.Length];
                 }
 
                 return _renderers;
@@ -612,6 +610,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
+            _newMultiplyColors ??= new Color[_renderers.Length];
+            _newScreenColors ??= new Color[_renderers.Length];
             var newMultiplyColors = _newMultiplyColors;
             var newScreenColors = _newScreenColors;
 
@@ -894,6 +894,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
+            _newMultiplyColors ??= new Color[_renderers.Length];
+            _newScreenColors ??= new Color[_renderers.Length];
             var newMultiplyColors = _newMultiplyColors;
             var newScreenColors = _newScreenColors;
 

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -496,13 +496,12 @@ namespace Live2D.Cubism.Rendering
         {
             get
             {
-                if (_renderers== null)
+                if (_renderers == null)
                 {
                     _renderers = Model.Drawables.GetComponentsMany<CubismRenderer>();
                     _newMultiplyColors = new Color[_renderers.Length];
                     _newScreenColors = new Color[_renderers.Length];
                 }
-
 
                 return _renderers;
             }
@@ -712,7 +711,7 @@ namespace Live2D.Cubism.Rendering
         public void OnLateUpdate()
         {
             // Fail silently...
-            if(!enabled)
+            if (!enabled)
             {
                 return;
             }
@@ -790,7 +789,7 @@ namespace Live2D.Cubism.Rendering
         /// </summary>
         private void LateUpdate()
         {
-            if(!HasUpdateController)
+            if (!HasUpdateController)
             {
                 OnLateUpdate();
             }

--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -479,6 +479,17 @@ namespace Live2D.Cubism.Rendering
         private CubismRenderer[] _renderers;
 
         /// <summary>
+        /// multiply color buffer.
+        /// </summary>
+        private Color[] _newMultiplyColors;
+
+        /// <summary>
+        /// screen color buffer.
+        /// </summary>
+        private Color[] _newScreenColors;
+
+
+        /// <summary>
         /// <see cref="CubismRenderer"/>s.
         /// </summary>
         public CubismRenderer[] Renderers
@@ -488,6 +499,8 @@ namespace Live2D.Cubism.Rendering
                 if (_renderers== null)
                 {
                     _renderers = Model.Drawables.GetComponentsMany<CubismRenderer>();
+                    _newMultiplyColors = new Color[_renderers.Length];
+                    _newScreenColors = new Color[_renderers.Length];
                 }
 
 
@@ -600,8 +613,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
-            var newMultiplyColors = new Color[Renderers.Length];
-            var newScreenColors = new Color[Renderers.Length];
+            var newMultiplyColors = _newMultiplyColors;
+            var newScreenColors = _newScreenColors;
 
             for (int i = 0; i < Renderers.Length; i++)
             {
@@ -882,8 +895,8 @@ namespace Live2D.Cubism.Rendering
 
             var isMultiplyColorUpdated = false;
             var isScreenColorUpdated = false;
-            var newMultiplyColors = new Color[Renderers.Length];
-            var newScreenColors = new Color[Renderers.Length];
+            var newMultiplyColors = _newMultiplyColors;
+            var newScreenColors = _newScreenColors;
 
             for (var i = 0; i < data.Length; ++i)
             {


### PR DESCRIPTION
Fixed a noticeable performance impact when running in Unity. Please check.

- CubismPhysicsSubRig [Reduced access to array indexes](https://github.com/Live2D/CubismUnityComponents/commit/7a98b94c957cc6f5ace9ce3f8ea9d73652fb5cf1)

Evaluate_before
![CubismPhysicsSubRig Evaluate_before](https://user-images.githubusercontent.com/781133/216782128-8d275837-715d-4194-8997-f443b379f974.png)

Evaluate_after
![CubismPhysicsSubRig Evaluate_after](https://user-images.githubusercontent.com/781133/216782146-6260fd9f-93bd-4a81-ae5d-e1b2fc00597b.png)


- CubismRenderController [Avoid allocating memory every frame.](https://github.com/Live2D/CubismUnityComponents/commit/322df2a3445ab61dda82b840eebc34463462e8b4)

UpdateBlendColors_before
![CubismRenderController UpdateBlendColors_before](https://user-images.githubusercontent.com/781133/216782211-235e8a92-e2e5-43e7-b535-1c9812b6bc83.png)

UpdateBlendColors_after
![CubismRenderController UpdateBlendColors_after](https://user-images.githubusercontent.com/781133/216782230-906f68ca-53ef-429a-86d5-5ecd054c977f.png)


OnDynamicDrawableData_before
![CubismRenderController OnDynamicDrawableData_before](https://user-images.githubusercontent.com/781133/216782241-b889ab8a-7b12-4600-85f4-63601a4cf009.png)

OnDynamicDrawableData_after
![CubismRenderController OnDynamicDrawableData_after](https://user-images.githubusercontent.com/781133/216782243-525296a3-65e4-49d3-911c-3b05ee6053ef.png)
