### PR TITLE
Update to Cubism 5 SDK for Unity R1 beta1

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -18,3 +18,6 @@ end_of_line = crlf
 [*.{anim,asset,controller,mat,meta,prefab,unity}]
 insert_final_newline = unset
 trim_trailing_whitespace = unset
+
+[*.md]
+trim_trailing_whitespace = false

--- a/Assets/Live2D/Cubism/CHANGELOG.md
+++ b/Assets/Live2D/Cubism/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.1-beta.1] - 2023-08-17
+
+### Changed
+
+* When importing a Cubism Model in Unity Workflow, the AnimatorController is now set to the Animator in the Model Prefab.
+* Change so that multiply and screen colors applied to parent parts are propagated to child parts.
+
+### Fixed
+
+* Fix an issue where information was being got using indexes instead of IDs when getting cdi3.json data.
+* Fix a bug that prevented proper operation when the Unity Transition was longer than the motion fade.
+
 
 ## [4-r.7] - 2023-05-25
 
@@ -303,6 +315,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue where Priority value was not reset after playing motion with CubismMotionController.
 
 
+[5-r.1-beta.1]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.7...5-r.1-beta.1
 [4-r.7]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6.2...4-r.7
 [4-r.6.2]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6...4-r.6.1

--- a/Assets/Live2D/Cubism/Core/CubismPart.cs
+++ b/Assets/Live2D/Cubism/Core/CubismPart.cs
@@ -95,6 +95,21 @@ namespace Live2D.Cubism.Core
         [SerializeField, HideInInspector]
         public float Opacity;
 
+        /// <summary>
+        /// Parent part position in unmanaged arrays.
+        /// </summary>
+        internal int UnmanagedParentIndex
+        {
+            get
+            {
+                if (UnmanagedIndex > 0)
+                {
+                    // Pull data.
+                    return UnmanagedParts.ParentIndices[UnmanagedIndex];
+                }
+                return -1;
+            }
+        }
 
         /// <summary>
         /// Revives instance.

--- a/Assets/Live2D/Cubism/Core/Unmanaged/CubismCoreDll.cs
+++ b/Assets/Live2D/Cubism/Core/Unmanaged/CubismCoreDll.cs
@@ -56,9 +56,13 @@ namespace Live2D.Cubism.Core.Unmanaged
         /// </sumamry>
         public const int MocVersion_40 = 3;
         /// <sumamry>
-        /// .moc3 file version 4.2.00 -
+        /// .moc3 file version 4.2.00 - 4.2.04
         /// </sumamry>
         public const int MocVersion_42 = 4;
+        /// <sumamry>
+        /// .moc3 file version 5.0.00 -
+        /// </sumamry>
+        public const int MocVersion_50 = 5;
 
 
         /// <sumamry>

--- a/Assets/Live2D/Cubism/Editor/Inspectors/CubismPartColorsEditorInspector.cs
+++ b/Assets/Live2D/Cubism/Editor/Inspectors/CubismPartColorsEditorInspector.cs
@@ -16,6 +16,7 @@ namespace Live2D.Cubism.Editor.Inspectors
     internal sealed class PortfolioPartBlendColorEditorInspector : UnityEditor.Editor
     {
         private SerializedProperty childDrawableRenderers;
+        private SerializedProperty childParts;
 
         #region Editor
 
@@ -37,11 +38,20 @@ namespace Live2D.Cubism.Editor.Inspectors
             {
                 childDrawableRenderers = serializedObject.FindProperty("_childDrawableRenderers");
             }
+            if (childParts == null)
+            {
+                childParts = serializedObject.FindProperty("_childParts");
+            }
 
             if (childDrawableRenderers != null)
             {
                 // Show renderers.
                 EditorGUILayout.PropertyField(childDrawableRenderers);
+            }
+            if (childParts != null)
+            {
+                // Show parts.
+                EditorGUILayout.PropertyField(childParts);
             }
 
             EditorGUI.BeginChangeCheck();

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionController.cs
@@ -28,6 +28,12 @@ namespace Live2D.Cubism.Framework.Expression
         public CubismExpressionList ExpressionsList;
 
         /// <summary>
+        /// Use the expression calculation method.
+        /// </summary>
+        [SerializeField]
+        public bool UseLegacyBlendCalculation = false;
+
+        /// <summary>
         /// CubismModel cache.
         /// </summary>
         private CubismModel _model = null;
@@ -54,6 +60,21 @@ namespace Live2D.Cubism.Framework.Expression
         [HideInInspector]
         public bool HasUpdateController { get; set; }
 
+        /// <summary>
+        /// Value of each parameter to be applied to the model.
+        /// </summary>
+        private List<CubismExpressionParameterValue> _expressionParameterValues = new List<CubismExpressionParameterValue>();
+
+        /// <summary>
+        /// Default value for applying additive.
+        /// </summary>
+        private const float DefaultAdditiveValue = 0.0f;
+
+        /// <summary>
+        /// Initial value of multiply applied.
+        /// </summary>
+        private const float DefaultMultiplyValue = 1.0f;
+
         #endregion
 
         /// <summary>
@@ -79,7 +100,7 @@ namespace Live2D.Cubism.Framework.Expression
             }
 
             // Fail silently...
-            if(CurrentExpressionIndex < 0 || CurrentExpressionIndex >= ExpressionsList.CubismExpressionObjects.Length)
+            if (CurrentExpressionIndex < 0 || CurrentExpressionIndex >= ExpressionsList.CubismExpressionObjects.Length)
             {
                 return;
             }
@@ -128,45 +149,48 @@ namespace Live2D.Cubism.Framework.Expression
                 StartExpression();
             }
 
+            // Update of expressions.
+            if (UseLegacyBlendCalculation)
+            {
+                UpdateExpressionLegacy();
+            }
+            else
+            {
+                UpdateExpression();
+            }
+        }
+
+        /// <summary>
+        /// Update of expressions. (old method)
+        /// </summary>
+        private void UpdateExpressionLegacy()
+        {
             // Update expression
-            for(var expressionIndex = 0; expressionIndex < _playingExpressions.Count; ++expressionIndex)
+            for (var expressionIndex = 0; expressionIndex < _playingExpressions.Count; ++expressionIndex)
             {
                 var playingExpression = _playingExpressions[expressionIndex];
 
-                // Update expression user time.
-                playingExpression.ExpressionUserTime += Time.deltaTime;
-
-                // Update weight
-                var fadeIn = (Mathf.Abs(playingExpression.FadeInTime) < float.Epsilon)
-                              ? 1.0f
-                              : CubismFadeMath.GetEasingSine(playingExpression.ExpressionUserTime / playingExpression.FadeInTime);
-
-                var fadeOut = ((Mathf.Abs(playingExpression.ExpressionEndTime) < float.Epsilon) || (playingExpression.ExpressionEndTime < 0.0f))
-                              ? 1.0f
-                              : CubismFadeMath.GetEasingSine(
-                                  (playingExpression.ExpressionEndTime - playingExpression.ExpressionUserTime) / playingExpression.FadeOutTime);
-
-                playingExpression.Weight = fadeIn * fadeOut;
+                UpdateFadeWeight(playingExpression);
 
                 // Apply value.
-                for(var i = 0; i < playingExpression.Destinations.Length; ++i)
+                for (var i = 0; i < playingExpression.Destinations.Length; ++i)
                 {
                     // Fail silently...
-                    if(playingExpression.Destinations[i] == null)
+                    if (playingExpression.Destinations[i] == null)
                     {
                         continue;
                     }
 
-                    switch(playingExpression.Blend[i])
+                    switch (playingExpression.Blend[i])
                     {
                         case CubismParameterBlendMode.Additive:
-                            playingExpression.Destinations[i].AddToValue(playingExpression.Value[i], playingExpression.Weight);
+                            playingExpression.Destinations[i].AddToValue(playingExpression.Value[i], playingExpression.FadeWeight);
                             break;
                         case CubismParameterBlendMode.Multiply:
-                            playingExpression.Destinations[i].MultiplyValueBy(playingExpression.Value[i], playingExpression.Weight);
+                            playingExpression.Destinations[i].MultiplyValueBy(playingExpression.Value[i], playingExpression.FadeWeight);
                             break;
                         case CubismParameterBlendMode.Override:
-                            playingExpression.Destinations[i].Value = playingExpression.Destinations[i].Value * (1 - playingExpression.Weight) + (playingExpression.Value[i] * playingExpression.Weight);
+                            playingExpression.Destinations[i].Value = playingExpression.Destinations[i].Value * (1 - playingExpression.FadeWeight) + (playingExpression.Value[i] * playingExpression.FadeInWeight);
                             break;
                         default:
                             // When an unspecified value is set, it is already in addition mode.
@@ -179,9 +203,9 @@ namespace Live2D.Cubism.Framework.Expression
             }
 
             // Remove expression from playing expressions
-            for(var expressionIndex = _playingExpressions.Count - 1; expressionIndex >= 0; --expressionIndex)
+            for (var expressionIndex = _playingExpressions.Count - 1; expressionIndex >= 0; --expressionIndex)
             {
-                if(_playingExpressions[expressionIndex].Weight > 0.0f)
+                if (_playingExpressions[expressionIndex].FadeWeight > 0.0f)
                 {
                     continue;
                 }
@@ -190,6 +214,240 @@ namespace Live2D.Cubism.Framework.Expression
             }
         }
 
+        /// <summary>
+        /// Update of expressions.
+        /// </summary>
+        private void UpdateExpression()
+        {
+            var expressionWeight = 0.0f;
+
+            // Update expression
+            for (var expressionIndex = 0; expressionIndex < _playingExpressions.Count; ++expressionIndex)
+            {
+                var playingExpression = _playingExpressions[expressionIndex];
+
+                // List all parameters referenced by the Expression being played.
+                for (var i = 0; i < playingExpression.Destinations.Length; ++i)
+                {
+                    var index = -1;
+                    // Search for the presence of a parameter ID in the list.
+                    for (var j = 0; j < _expressionParameterValues.Count; j++)
+                    {
+                        if (_expressionParameterValues[j].Parameter != playingExpression.Destinations[i])
+                        {
+                            continue;
+                        }
+
+                        index = j;
+                        break;
+                    }
+
+                    if (index >= 0)
+                    {
+                        continue;
+                    }
+
+                    // If the parameter does not exist in the list, add a new one.
+                    CubismExpressionParameterValue item = new CubismExpressionParameterValue();
+                    item.Parameter = playingExpression.Destinations[i];
+                    item.AdditiveValue = DefaultAdditiveValue;
+                    item.MultiplyValue = DefaultMultiplyValue;
+                    item.OverwriteValue = item.Parameter.Value;
+                    _expressionParameterValues.Add(item);
+                }
+
+                // ------ Calculate value ------
+                CalculateExpressionParameters(expressionIndex, playingExpression);
+
+                expressionWeight += playingExpression.FadeInTime == 0.0f
+                    ? 1.0f
+                    : CubismFadeMath.GetEasingSine(
+                        (playingExpression.ExpressionUserTime - playingExpression.ExpressionStartTime) /
+                        playingExpression.FadeInTime);
+            }
+
+            // ----- If the latest Expression fade is complete, delete the earlier one. ------
+            if (_playingExpressions.Count > 1 &&
+                _playingExpressions[_playingExpressions.Count-1].FadeWeight >= 1.0f)
+            {
+                // The last element of the array is not deleted.
+                for (var i = _playingExpressions.Count - 2; i >= 0; --i)
+                {
+                    _playingExpressions.RemoveAt(i);
+                }
+            }
+
+            if (expressionWeight > 1.0f)
+            {
+                expressionWeight = 1.0f;
+            }
+
+            // Apply each value to the model.
+            for (var i = 0; i < _expressionParameterValues.Count; i++)
+            {
+                var expressionParameterValue = _expressionParameterValues[i];
+                expressionParameterValue.Parameter.BlendToValue(CubismParameterBlendMode.Override,
+                    (expressionParameterValue.OverwriteValue + expressionParameterValue.AdditiveValue)
+                        * expressionParameterValue.MultiplyValue,
+                    expressionWeight);
+
+                expressionParameterValue.AdditiveValue = DefaultAdditiveValue;
+                expressionParameterValue.MultiplyValue = DefaultMultiplyValue;
+            }
+        }
+
+        /// <summary>
+        /// Update motion weights.
+        /// </summary>
+        /// <param name="playingExpression">Expression motion during playback.</param>
+        private void UpdateFadeWeight(CubismPlayingExpression playingExpression)
+        {
+            // Update expression user time.
+            playingExpression.ExpressionUserTime += Time.deltaTime;
+
+            // Update weight
+            playingExpression.FadeInWeight = (Mathf.Abs(playingExpression.FadeInTime) < float.Epsilon)
+                ? 1.0f
+                : CubismFadeMath.GetEasingSine(playingExpression.ExpressionUserTime / playingExpression.FadeInTime);
+
+            playingExpression.FadeOutWeight = ((Mathf.Abs(playingExpression.ExpressionEndTime) < float.Epsilon) || (playingExpression.ExpressionEndTime < 0.0f))
+                ? 1.0f
+                : CubismFadeMath.GetEasingSine(
+                    (playingExpression.ExpressionEndTime - playingExpression.ExpressionUserTime) / playingExpression.FadeOutTime);
+
+            playingExpression.FadeWeight = playingExpression.Weight * playingExpression.FadeInWeight * playingExpression.FadeOutWeight;
+        }
+
+        /// <summary>
+        /// Calculate parameters related to the model's facial expressions.
+        /// </summary>
+        /// <param name="expressionIndex">Index of currently processed facial expression motion.</param>
+        /// <param name="playingExpression">Expression motion during playback.</param>
+        private void CalculateExpressionParameters(int expressionIndex, CubismPlayingExpression playingExpression)
+        {
+            UpdateFadeWeight(playingExpression);
+
+            for (var i = 0; i < _expressionParameterValues.Count; i++)
+            {
+                var expressionParameterValue = _expressionParameterValues[i];
+
+                if (expressionParameterValue.Parameter == null)
+                {
+                    continue;
+                }
+
+                var currentParameterValue = expressionParameterValue.OverwriteValue =
+                    expressionParameterValue.Parameter.Value;
+
+                var expressionParameters = playingExpression.Destinations;
+                var parameterIndex = -1;
+                for (var j = 0; j < expressionParameters.Length; j++)
+                {
+                    if (expressionParameterValue.Parameter != expressionParameters[j])
+                    {
+                        continue;
+                    }
+
+                    parameterIndex = j;
+
+                    break;
+                }
+
+                // Parameters not referenced by the Expression being played have their initial values applied.
+                if (parameterIndex < 0)
+                {
+                    if (expressionIndex == 0)
+                    {
+                        expressionParameterValue.AdditiveValue = DefaultAdditiveValue;
+                        expressionParameterValue.MultiplyValue = DefaultMultiplyValue;
+                        expressionParameterValue.OverwriteValue = currentParameterValue;
+                    }
+                    else
+                    {
+                        expressionParameterValue.AdditiveValue =
+                            CalculateValue(
+                                expressionParameterValue.AdditiveValue,
+                                DefaultAdditiveValue,
+                                playingExpression.FadeWeight);
+                        expressionParameterValue.MultiplyValue =
+                            CalculateValue(
+                                expressionParameterValue.MultiplyValue,
+                                DefaultMultiplyValue,
+                                playingExpression.FadeWeight);
+                        expressionParameterValue.OverwriteValue =
+                            CalculateValue(
+                                expressionParameterValue.OverwriteValue,
+                                currentParameterValue,
+                                playingExpression.FadeWeight);
+                    }
+
+                    _expressionParameterValues[i] = expressionParameterValue;
+                    continue;
+                }
+
+                // Calculate value.
+                var value = playingExpression.Value[parameterIndex];
+                float newAdditiveValue, newMultiplyValue, newSetValue;
+                switch (playingExpression.Blend[parameterIndex])
+                {
+                    case CubismParameterBlendMode.Additive:
+                        newAdditiveValue = value;
+                        newMultiplyValue = DefaultMultiplyValue;
+                        newSetValue = currentParameterValue;
+                        break;
+                    case CubismParameterBlendMode.Multiply:
+                        newAdditiveValue = DefaultAdditiveValue;
+                        newMultiplyValue = value;
+                        newSetValue = currentParameterValue;
+                        break;
+                    case CubismParameterBlendMode.Override:
+                        newAdditiveValue = DefaultAdditiveValue;
+                        newMultiplyValue = DefaultMultiplyValue;
+                        newSetValue = value;
+                        break;
+                    default:
+                        return;
+                }
+
+                if (expressionIndex == 0)
+                {
+                    expressionParameterValue.AdditiveValue = newAdditiveValue;
+                    expressionParameterValue.MultiplyValue = newMultiplyValue;
+                    expressionParameterValue.OverwriteValue = newSetValue;
+                }
+                else
+                {
+                    expressionParameterValue.AdditiveValue =
+                        CalculateValue(
+                            expressionParameterValue.AdditiveValue,
+                            newAdditiveValue,
+                            playingExpression.FadeWeight);
+                    expressionParameterValue.MultiplyValue =
+                        CalculateValue(
+                            expressionParameterValue.MultiplyValue,
+                            newMultiplyValue,
+                            playingExpression.FadeWeight);
+                    expressionParameterValue.OverwriteValue =
+                        CalculateValue(
+                            expressionParameterValue.OverwriteValue,
+                            newSetValue,
+                            playingExpression.FadeWeight);
+                }
+                _expressionParameterValues[i] = expressionParameterValue;
+            }
+        }
+
+        /// <summary>
+        /// Blend calculation.
+        /// </summary>
+        /// <param name="source">Source value.</param>
+        /// <param name="destination">Destination value.</param>
+        /// <param name="fadeWeight">Weight value.</param>
+        /// <returns></returns>
+        private float CalculateValue(float source, float destination, float fadeWeight)
+        {
+            return (source * (1.0f - fadeWeight)) + (destination * fadeWeight);
+        }
 
         #region Unity Event Handling
 

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionParameterValue.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionParameterValue.cs
@@ -1,0 +1,23 @@
+﻿/**
+ * Copyright(c) Live2D Inc. All rights reserved.
+ *
+ * Use of this source code is governed by the Live2D Open Software license
+ * that can be found at https://www.live2d.com/eula/live2d-open-software-license-agreement_en.html.
+ */
+
+
+using Live2D.Cubism.Core;
+
+namespace Live2D.Cubism.Framework.Expression
+{
+    /**
+     * @brief Structure that allows parameters to have expression values to be applied.
+     */
+    public struct CubismExpressionParameterValue
+    {
+        public CubismParameter Parameter;   ///< Parameter id.
+        public float AdditiveValue;         ///< Additive value.
+        public float MultiplyValue;         ///< Multiply value.
+        public float OverwriteValue;        ///< Overwrite value.
+    }
+}

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionParameterValue.cs.meta
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismExpressionParameterValue.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 72362d80f8b420a40b445bc1ebae1735
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Framework/Expression/CubismPlayingExpression.cs
+++ b/Assets/Live2D/Cubism/Framework/Expression/CubismPlayingExpression.cs
@@ -6,6 +6,7 @@
  */
 
 
+using System;
 using Live2D.Cubism.Core;
 using UnityEngine;
 
@@ -50,6 +51,12 @@ namespace Live2D.Cubism.Framework.Expression
         public float ExpressionUserTime;
 
         /// <summary>
+        /// Expression start time.
+        /// </summary>
+        [SerializeField]
+        public float ExpressionStartTime;
+
+        /// <summary>
         /// Expression end time.
         /// </summary>
         [SerializeField]
@@ -72,6 +79,24 @@ namespace Live2D.Cubism.Framework.Expression
         /// </summary>
         [SerializeField]
         public CubismParameterBlendMode[] Blend;
+
+        /// <summary>
+        /// Expression fade weight.
+        /// </summary>
+        [NonSerialized, HideInInspector]
+        public float FadeWeight;
+
+        /// <summary>
+        /// Expression fade in weight.
+        /// </summary>
+        [NonSerialized, HideInInspector]
+        public float FadeInWeight;
+
+        /// <summary>
+        /// Expression fade out weight.
+        /// </summary>
+        [NonSerialized, HideInInspector]
+        public float FadeOutWeight;
 
         #endregion
 
@@ -100,8 +125,9 @@ namespace Live2D.Cubism.Framework.Expression
                                 ? 1.0f
                                 : expressionData.FadeOutTime;
 
-            ret.Weight = 0.0f;
+            ret.Weight = 1.0f;
             ret.ExpressionUserTime = 0.0f;
+            ret.ExpressionStartTime = 0.0f;
             ret.ExpressionEndTime = 0.0f;
 
             var parameterCount = expressionData.Parameters.Length;

--- a/Assets/Live2D/Cubism/Framework/Json/CubismModel3Json.cs
+++ b/Assets/Live2D/Cubism/Framework/Json/CubismModel3Json.cs
@@ -428,7 +428,7 @@ namespace Live2D.Cubism.Framework.Json
                 for (int i = 0; i < parts.Length; i++)
                 {
                     var partColorsEditor = parts[i].gameObject.AddComponent<CubismPartColorsEditor>();
-                    partColorsEditor.TryInitialize(rendererController, parts[i], model.Drawables);
+                    partColorsEditor.TryInitialize(model);
                 }
             }
 
@@ -459,7 +459,6 @@ namespace Live2D.Cubism.Framework.Json
 
             // Initialize groups.
             var parameters = model.Parameters;
-
 
             for (var i = 0; i < parameters.Length; ++i)
             {
@@ -492,10 +491,17 @@ namespace Live2D.Cubism.Framework.Json
                 if (cdi3Json != null)
                 {
                     var cubismDisplayInfoParameterName = parameters[i].gameObject.AddComponent<CubismDisplayInfoParameterName>();
-                    cubismDisplayInfoParameterName.Name = cdi3Json.Parameters[i].Name;
+                    cubismDisplayInfoParameterName.Name = parameters[i].Id;
+                    for (int j = 0; j < cdi3Json.Parameters.Length; j++)
+                    {
+                        if (cdi3Json.Parameters[j].Id == parameters[i].Id)
+                        {
+                            cubismDisplayInfoParameterName.Name = cdi3Json.Parameters[j].Name;
+                            break;
+                        }
+                    }
                     cubismDisplayInfoParameterName.DisplayName = string.Empty;
                 }
-
             }
 
             // Setting up the part name for display.
@@ -507,7 +513,15 @@ namespace Live2D.Cubism.Framework.Json
                 for (var i = 0; i < parts.Length; i++)
                 {
                     var cubismDisplayInfoPartNames = parts[i].gameObject.AddComponent<CubismDisplayInfoPartName>();
-                    cubismDisplayInfoPartNames.Name = cdi3Json.Parts[i].Name;
+                    cubismDisplayInfoPartNames.Name = parts[i].Id;
+                    for (int j = 0; j < cdi3Json.Parts.Length; j++)
+                    {
+                        if (cdi3Json.Parts[j].Id == parts[i].Id)
+                        {
+                            cubismDisplayInfoPartNames.Name = cdi3Json.Parts[j].Name;
+                            break;
+                        }
+                    }
                     cubismDisplayInfoPartNames.DisplayName = string.Empty;
                 }
             }

--- a/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeController.cs
@@ -157,7 +157,8 @@ namespace Live2D.Cubism.Framework.MotionFade
                 {
                     if ((elapsedTime <= playingMotionData.FadeInTime) ||
                         ((0 <= playingMotionData.ParameterFadeInTimes[j]) &&
-                          (elapsedTime <= playingMotionData.ParameterFadeInTimes[j])))
+                         (elapsedTime <= playingMotionData.ParameterFadeInTimes[j])) ||
+                        !_fadeStates[i].GetStateTransitionFinished())
                     {
                         _isFading[i] = true;
                         break;

--- a/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeStateObserver.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/CubismFadeStateObserver.cs
@@ -141,6 +141,7 @@ namespace Live2D.Cubism.Framework.MotionFade
             }
 
             _cubismFadeMotionList = fadeController.CubismFadeMotionList;
+            _isStateTransitionFinished = false;
 
             _layerIndex = layerIndex;
             _layerWeight = (_layerIndex == 0)

--- a/Assets/Live2D/Cubism/Framework/MotionFade/Editor/CubismFadeMotionImporter.cs
+++ b/Assets/Live2D/Cubism/Framework/MotionFade/Editor/CubismFadeMotionImporter.cs
@@ -46,9 +46,33 @@ namespace Live2D.Cubism.Framework.MotionFade
             var dataPath = Directory.GetParent(Application.dataPath).FullName + "/";
             var assetPath = importer.AssetPath.Replace(".model3.json", ".controller");
 
+            var animator = model.GetComponent<Animator>();
+
             if (!File.Exists(dataPath + assetPath))
             {
-                CreateAnimatorController(assetPath);
+                var controller = CreateAnimatorController(assetPath);
+
+                if (!CubismUnityEditorMenu.ShouldImportAsOriginalWorkflow)
+                {
+                    if (animator != null)
+                    {
+                        animator.runtimeAnimatorController = controller;
+                    }
+                }
+            }
+            else
+            {
+                if (animator != null)
+                {
+                    if (CubismUnityEditorMenu.ShouldImportAsOriginalWorkflow)
+                    {
+                        animator.runtimeAnimatorController = null;
+                    }
+                    else
+                    {
+                        animator.runtimeAnimatorController = AssetDatabase.LoadAssetAtPath<AnimatorController>(assetPath);
+                    }
+                }
             }
 
             var fadeController = model.GetComponent<CubismFadeController>();

--- a/Assets/Live2D/Cubism/NOTICE.ja.md
+++ b/Assets/Live2D/Cubism/NOTICE.ja.md
@@ -4,23 +4,6 @@
 
 # お知らせ
 
-## [注意事項] Unity 2022 での動作について (2022-09-08)
-
-本 Cubism SDK におきまして、`2022.1.14f1` にて Unity Editor 上と成果物の動作を確認しております。
-ただし、試験的な動作確認であり、Unity Editor からの書き出し機能等含む全ての機能が正しく動作することを保証するものではございません。
-アプリケーションに組み込み製品として利用する際は、Unity 2021 等 LTSバージョンのご利用をご検討ください。
-
-対応する Unity のバージョンについては、`README.ja.md` の[開発環境](README.ja.md#開発環境)をご参照ください。
-
-
-## [制限事項] Apple製品の対応状況について (2023-01-26 更新)
-
-Apple Silicon製のMacにつきまして、Cubism 4 SDK for Unity R4 (4-r.4) にて対応いたしました。
-※Cubism Editorは現在Apple Silicon製のMacに対応しておりません、ご了承ください。
-
-また、macOS Ventura v13.0以降につきましては動作を保証しておりません、ご了承ください。
-
-
 ## [注意事項] Apple Silicon版 Unity Editor での動作について (2023-01-26)
 
 Apple Silicon版Unity Editorでの動作につきまして、macOS向けのCubism Coreを利用するには `Assets/Live2D/Cubism/Plugins/macOS` 以下にある `Live2DCubismCore.bundle` をインスペクタから操作する必要があります。

--- a/Assets/Live2D/Cubism/NOTICE.md
+++ b/Assets/Live2D/Cubism/NOTICE.md
@@ -4,22 +4,6 @@
 
 # Notices
 
-## [Caution] Support for Unity 2022 (2022-09-08)
-
-We have confirmed the operation of the Cubism SDK with `2022.1.14f1` on the Unity Editor.
-However, this is a test run and we do not guarantee that all functions, including export from Unity Editor, will work properly.
-Please consider using Unity 2021 or other LTS versions when using the product as an embedded product in your application.
-
-Please refer to [Development Environment](README.md#Developmentenvironment) in the `README.md` for the supported Unity versions.
-
-
-## [Limitation] Support for Apple products (updated 2023-01-26)
-
-Apple Silicon Mac is now supported by the Cubism 4 SDK for Unity R4 (4-r.4).
-† Please note that Cubism Editor is not currently compatible with Apple Silicon Macs.
-In addition, please note that we do not work on macOS Ventura v13.0.
-
-
 ## [Caution] Operation on the Apple Silicon version of Unity Editor (2023-01-26)
 
 To use Cubism Core for macOS on the Apple Silicon version of the Unity Editor, you need to modify the `Live2DCubismCore.bundle` under `Assets/Live2D/Cubism/Plugins/macOS` from the inspector.

--- a/Assets/Live2D/Cubism/Plugins/CHANGELOG.md
+++ b/Assets/Live2D/Cubism/Plugins/CHANGELOG.md
@@ -4,6 +4,26 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+
+## 2023-08-17
+
+### Added
+
+* Enhance Blend Shape features.
+  * Please see [here](https://docs.live2d.com/en/cubism-editor-manual/blend-shape/).
+
+### Changed
+
+* Upgrade Core version to 05.00.0000.
+
+
+## 2023-05-09
+
+### Changed
+
+* Change the GCC version of the library for Linux from 6.5.0 to 8.3.0.
+
+
 ## 2023-03-16
 
 ### Fixed

--- a/Assets/Live2D/Cubism/README.ja.md
+++ b/Assets/Live2D/Cubism/README.ja.md
@@ -2,9 +2,11 @@
 
 ---
 
-# CubismUnityComponents
+# Cubism Unity Components
 
-Unity用のCubismSDKのオープンコンポーネントです。
+Unity用のCubism SDKのオープンコンポーネントです。
+
+モデルをロードするには Live2D Cubism Core と組み合わせて使用します。
 
 SDKパッケージのダウンロードページをお探しの場合は、[ダウンロードページ](https://www.live2d.com/download/cubism-sdk/download-unity/)にアクセスしてください。
 
@@ -15,6 +17,12 @@ SDKパッケージのダウンロードページをお探しの場合は、[ダ�
 ## お知らせ
 
 ご使用前に[お知らせ](NOTICE.ja.md)をお読みください。
+
+## Cubism 5新機能や過去バージョンとの互換性について
+
+本 SDK はCubism 5に対応した製品です。  
+Cubism 5 Editorに搭載された新機能のSDK対応については [こちら](https://docs.live2d.com/cubism-sdk-manual/cubism-5-new-functions/)をご確認ください。  
+過去バージョンのCubism SDKとの互換性については [こちら](https://docs.live2d.com/cubism-sdk-manual/compatibility-with-cubism-5/)をご確認ください。
 
 ## 構造
 
@@ -46,16 +54,16 @@ Unity Editor拡張機能は、`./Assets/Live2D/Cubism/Editor`にあります。
 
 | Unity | バージョン |
 | --- | --- |
-| Tech Stream | 2022.2.18f1 |
-| LTS | 2021.3.24f1 |
-| LTS | 2020.3.47f1 |
+| LTS | 2022.3.6f1 |
+| LTS | 2021.3.29f1 |
+| LTS | 2020.3.48f1 |
 
 | ライブラリ / ツール | バージョン |
 | --- | --- |
 | Android SDK / NDK | *1 |
-| Visual Studio 2022 | 17.5.5 |
+| Visual Studio 2022 | 17.7.0 |
 | Windows SDK | 10.0.22621.0 |
-| Xcode | 14.2 |
+| Xcode | 14.3.1 |
 
 *1 Unityに組み込まれたライブラリまたは推奨ライブラリを使用してください。
 
@@ -74,14 +82,14 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | プラットフォーム | バージョン |
 | --- | --- |
 | Android | 13 |
-| iOS | 16.4.1 |
-| iPadOS | 16.4.1 |
+| iOS | 16.6 |
+| iPadOS | 16.6 |
 | Ubuntu | 20.04.6 |
-| macOS | 13.3.1 |
+| macOS | 13.5 |
 | Windows 10 | 22H2 |
-| Google Chrome | 113.0.5672.93 |
-| Chrome OS 64bit (x86_64) | 113.0.5672.114 |
-| Chrome OS 32bit (ARMv8) (*2) | 113.0.5672.114 |
+| Google Chrome | 115.0.5790.171 |
+| Chrome OS 64bit (x86_64) | 115.0.5790.160 |
+| Chrome OS 32bit (ARMv8) (*2) | 115.0.5790.160 |
 
 *2 Android向けAPKファイルでの動作確認です。
 

--- a/Assets/Live2D/Cubism/README.md
+++ b/Assets/Live2D/Cubism/README.md
@@ -6,6 +6,8 @@
 
 Welcome to the open components of the Cubism SDK for Unity.
 
+It is used in conjunction with the Live2D Cubism Core.
+
 Go [here](https://www.live2d.com/download/cubism-sdk/download-unity/) if you're looking for the download page of the SDK package.
 
 ## License
@@ -15,6 +17,13 @@ Please read the [license](LICENSE.md) before use.
 ## Notices
 
 Please read the [notices](NOTICE.md) before use.
+
+## Compatibility with Cubism 5 new features and previous Cubism SDK versions
+
+This SDK is compatible with Cubism 5.  
+For SDK compatibility with new features in Cubism 5 Editor, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/cubism-5-new-functions/).  
+For compatibility with previous versions of Cubism SDK, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/compatibility-with-cubism-5/).
+
 
 ## Structure
 
@@ -46,16 +55,16 @@ Resources like shaders and other assets are located in `./Assets/Live2D/Cubism/R
 
 | Unity | Version |
 | --- | --- |
-| Tech Stream | 2022.2.18f1 |
-| LTS | 2021.3.24f1 |
-| LTS | 2020.3.47f1 |
+| LTS | 2022.3.6f1 |
+| LTS | 2021.3.29f1 |
+| LTS | 2020.3.48f1 |
 
 | Library / Tool | Version |
 | --- | --- |
 | Android SDK / NDK | *1 |
-| Visual Studio 2022 | 17.5.5 |
+| Visual Studio 2022 | 17.7.0 |
 | Windows SDK | 10.0.22621.0 |
-| Xcode | 14.2 |
+| Xcode | 14.3.1 |
 
 *1 Use libraries embedded with Unity or recommended.
 
@@ -74,14 +83,14 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Platform | Version |
 | --- | --- |
 | Android | 13 |
-| iOS | 16.4.1 |
-| iPadOS | 16.4.1 |
+| iOS | 16.6 |
+| iPadOS | 16.6 |
 | Ubuntu | 20.04.6 |
-| macOS | 13.3.1 |
+| macOS | 13.5 |
 | Windows 10 | 22H2 |
-| Google Chrome | 113.0.5672.93 |
-| Chrome OS 64bit (x86_64) | 113.0.5672.114 |
-| Chrome OS 32bit (ARMv8) (*2) | 113.0.5672.114 |
+| Google Chrome | 115.0.5790.171 |
+| Chrome OS 64bit (x86_64) | 115.0.5790.160 |
+| Chrome OS 32bit (ARMv8) (*2) | 115.0.5790.160 |
 
 *2 This is a confirmation of operation with APK files for Android.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.1-beta.1] - 2023-08-17
+
+### Changed
+
+* When importing a Cubism Model in Unity Workflow, the AnimatorController is now set to the Animator in the Model Prefab.
+* Change so that multiply and screen colors applied to parent parts are propagated to child parts.
+
+### Fixed
+
+* Fix an issue where information was being got using indexes instead of IDs when getting cdi3.json data.
+* Fix a bug that prevented proper operation when the Unity Transition was longer than the motion fade.
+
 
 ## [4-r.7] - 2023-05-25
 
@@ -303,6 +315,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue where Priority value was not reset after playing motion with CubismMotionController.
 
 
+[5-r.1-beta.1]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.7...5-r.1-beta.1
 [4-r.7]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6.2...4-r.7
 [4-r.6.2]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6.1...4-r.6.2
 [4-r.6.1]: https://github.com/Live2D/CubismUnityComponents/compare/4-r.6...4-r.6.1

--- a/NOTICE.ja.md
+++ b/NOTICE.ja.md
@@ -4,23 +4,6 @@
 
 # お知らせ
 
-## [注意事項] Unity 2022 での動作について (2022-09-08)
-
-本 Cubism SDK におきまして、`2022.1.14f1` にて Unity Editor 上と成果物の動作を確認しております。
-ただし、試験的な動作確認であり、Unity Editor からの書き出し機能等含む全ての機能が正しく動作することを保証するものではございません。
-アプリケーションに組み込み製品として利用する際は、Unity 2021 等 LTSバージョンのご利用をご検討ください。
-
-対応する Unity のバージョンについては、`README.ja.md` の[開発環境](README.ja.md#開発環境)をご参照ください。
-
-
-## [制限事項] Apple製品の対応状況について (2023-01-26 更新)
-
-Apple Silicon製のMacにつきまして、Cubism 4 SDK for Unity R4 (4-r.4) にて対応いたしました。
-※Cubism Editorは現在Apple Silicon製のMacに対応しておりません、ご了承ください。
-
-また、macOS Ventura v13.0以降につきましては動作を保証しておりません、ご了承ください。
-
-
 ## [注意事項] Apple Silicon版 Unity Editor での動作について (2023-01-26)
 
 Apple Silicon版Unity Editorでの動作につきまして、macOS向けのCubism Coreを利用するには `Assets/Live2D/Cubism/Plugins/macOS` 以下にある `Live2DCubismCore.bundle` をインスペクタから操作する必要があります。

--- a/NOTICE.md
+++ b/NOTICE.md
@@ -4,22 +4,6 @@
 
 # Notices
 
-## [Caution] Support for Unity 2022 (2022-09-08)
-
-We have confirmed the operation of the Cubism SDK with `2022.1.14f1` on the Unity Editor.
-However, this is a test run and we do not guarantee that all functions, including export from Unity Editor, will work properly.
-Please consider using Unity 2021 or other LTS versions when using the product as an embedded product in your application.
-
-Please refer to [Development Environment](README.md#Developmentenvironment) in the `README.md` for the supported Unity versions.
-
-
-## [Limitation] Support for Apple products (updated 2023-01-26)
-
-Apple Silicon Mac is now supported by the Cubism 4 SDK for Unity R4 (4-r.4).
-† Please note that Cubism Editor is not currently compatible with Apple Silicon Macs.
-In addition, please note that we do not work on macOS Ventura v13.0.
-
-
 ## [Caution] Operation on the Apple Silicon version of Unity Editor (2023-01-26)
 
 To use Cubism Core for macOS on the Apple Silicon version of the Unity Editor, you need to modify the `Live2DCubismCore.bundle` under `Assets/Live2D/Cubism/Plugins/macOS` from the inspector.

--- a/README.ja.md
+++ b/README.ja.md
@@ -2,9 +2,11 @@
 
 ---
 
-# CubismUnityComponents
+# Cubism Unity Components
 
-Unity用のCubismSDKのオープンコンポーネントです。
+Unity用のCubism SDKのオープンコンポーネントです。
+
+モデルをロードするには Live2D Cubism Core と組み合わせて使用します。
 
 SDKパッケージのダウンロードページをお探しの場合は、[ダウンロードページ](https://www.live2d.com/download/cubism-sdk/download-unity/)にアクセスしてください。
 
@@ -15,6 +17,12 @@ SDKパッケージのダウンロードページをお探しの場合は、[ダ�
 ## お知らせ
 
 ご使用前に[お知らせ](NOTICE.ja.md)をお読みください。
+
+## Cubism 5新機能や過去バージョンとの互換性について
+
+本 SDK はCubism 5に対応した製品です。  
+Cubism 5 Editorに搭載された新機能のSDK対応については [こちら](https://docs.live2d.com/cubism-sdk-manual/cubism-5-new-functions/)をご確認ください。  
+過去バージョンのCubism SDKとの互換性については [こちら](https://docs.live2d.com/cubism-sdk-manual/compatibility-with-cubism-5/)をご確認ください。
 
 ## 構造
 
@@ -46,16 +54,16 @@ Unity Editor拡張機能は、`./Assets/Live2D/Cubism/Editor`にあります。
 
 | Unity | バージョン |
 | --- | --- |
-| Tech Stream | 2022.2.18f1 |
-| LTS | 2021.3.24f1 |
-| LTS | 2020.3.47f1 |
+| LTS | 2022.3.6f1 |
+| LTS | 2021.3.29f1 |
+| LTS | 2020.3.48f1 |
 
 | ライブラリ / ツール | バージョン |
 | --- | --- |
 | Android SDK / NDK | *1 |
-| Visual Studio 2022 | 17.5.5 |
+| Visual Studio 2022 | 17.7.0 |
 | Windows SDK | 10.0.22621.0 |
-| Xcode | 14.2 |
+| Xcode | 14.3.1 |
 
 *1 Unityに組み込まれたライブラリまたは推奨ライブラリを使用してください。
 
@@ -74,14 +82,14 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | プラットフォーム | バージョン |
 | --- | --- |
 | Android | 13 |
-| iOS | 16.4.1 |
-| iPadOS | 16.4.1 |
+| iOS | 16.6 |
+| iPadOS | 16.6 |
 | Ubuntu | 20.04.6 |
-| macOS | 13.3.1 |
+| macOS | 13.5 |
 | Windows 10 | 22H2 |
-| Google Chrome | 113.0.5672.93 |
-| Chrome OS 64bit (x86_64) | 113.0.5672.114 |
-| Chrome OS 32bit (ARMv8) (*2) | 113.0.5672.114 |
+| Google Chrome | 115.0.5790.171 |
+| Chrome OS 64bit (x86_64) | 115.0.5790.160 |
+| Chrome OS 32bit (ARMv8) (*2) | 115.0.5790.160 |
 
 *2 Android向けAPKファイルでの動作確認です。
 

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 
 Welcome to the open components of the Cubism SDK for Unity.
 
+It is used in conjunction with the Live2D Cubism Core.
+
 Go [here](https://www.live2d.com/download/cubism-sdk/download-unity/) if you're looking for the download page of the SDK package.
 
 ## License
@@ -15,6 +17,13 @@ Please read the [license](LICENSE.md) before use.
 ## Notices
 
 Please read the [notices](NOTICE.md) before use.
+
+## Compatibility with Cubism 5 new features and previous Cubism SDK versions
+
+This SDK is compatible with Cubism 5.  
+For SDK compatibility with new features in Cubism 5 Editor, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/cubism-5-new-functions/).  
+For compatibility with previous versions of Cubism SDK, please refer to [here](https://docs.live2d.com/en/cubism-sdk-manual/compatibility-with-cubism-5/).
+
 
 ## Structure
 
@@ -46,16 +55,16 @@ Resources like shaders and other assets are located in `./Assets/Live2D/Cubism/R
 
 | Unity | Version |
 | --- | --- |
-| Tech Stream | 2022.2.18f1 |
-| LTS | 2021.3.24f1 |
-| LTS | 2020.3.47f1 |
+| LTS | 2022.3.6f1 |
+| LTS | 2021.3.29f1 |
+| LTS | 2020.3.48f1 |
 
 | Library / Tool | Version |
 | --- | --- |
 | Android SDK / NDK | *1 |
-| Visual Studio 2022 | 17.5.5 |
+| Visual Studio 2022 | 17.7.0 |
 | Windows SDK | 10.0.22621.0 |
-| Xcode | 14.2 |
+| Xcode | 14.3.1 |
 
 *1 Use libraries embedded with Unity or recommended.
 
@@ -74,14 +83,14 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Platform | Version |
 | --- | --- |
 | Android | 13 |
-| iOS | 16.4.1 |
-| iPadOS | 16.4.1 |
+| iOS | 16.6 |
+| iPadOS | 16.6 |
 | Ubuntu | 20.04.6 |
-| macOS | 13.3.1 |
+| macOS | 13.5 |
 | Windows 10 | 22H2 |
-| Google Chrome | 113.0.5672.93 |
-| Chrome OS 64bit (x86_64) | 113.0.5672.114 |
-| Chrome OS 32bit (ARMv8) (*2) | 113.0.5672.114 |
+| Google Chrome | 115.0.5790.171 |
+| Chrome OS 64bit (x86_64) | 115.0.5790.160 |
+| Chrome OS 32bit (ARMv8) (*2) | 115.0.5790.160 |
 
 *2 This is a confirmation of operation with APK files for Android.
 


### PR DESCRIPTION
### Changed

* When importing a Cubism Model in Unity Workflow, the AnimatorController is now set to the Animator in the Model Prefab.
* Change so that multiply and screen colors applied to parent parts are propagated to child parts.

### Fixed

* Fix an issue where information was being got using indexes instead of IDs when getting cdi3.json data.
* Fix a bug that prevented proper operation when the Unity Transition was longer than the motion fade.