### PR TITLE
Update to Cubism 5 SDK for Unity R2

### DIFF
--- a/Assets/Live2D/Cubism/CHANGELOG.md
+++ b/Assets/Live2D/Cubism/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.2] - 2024-04-04
+
+### Added
+
+* Add HarmonyOS NEXT from the tested environment.
+
+### Fixed
+
+* Fix an issue where the `Allow 'unsafe' Code` property was not enabled in the `Live2D.Cubism.asmdef`.
+
 
 ## [5-r.1] - 2024-03-26
 
@@ -396,6 +406,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue where Priority value was not reset after playing motion with CubismMotionController.
 
 
+[5-r.2]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.4...5-r.1
 [5-r.1-beta.4]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.3...5-r.1-beta.4
 [5-r.1-beta.3]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.2...5-r.1-beta.3

--- a/Assets/Live2D/Cubism/Live2D.Cubism.asmdef
+++ b/Assets/Live2D/Cubism/Live2D.Cubism.asmdef
@@ -1,3 +1,14 @@
 {
-	"name": "Live2D.Cubism"
+    "name": "Live2D.Cubism",
+    "rootNamespace": "",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": true,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
 }

--- a/Assets/Live2D/Cubism/Plugins/CHANGELOG.md
+++ b/Assets/Live2D/Cubism/Plugins/CHANGELOG.md
@@ -5,6 +5,13 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 
+## 2024-04-04
+
+### Added
+
+* [Unity] Add library(.so) for HarmonyOS build.
+
+
 ## 2024-03-26
 
 ### Remove

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0b7e39b1069e2e94cb4aa149ef94ee8d
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/arm64-v8a.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/arm64-v8a.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c0d3e8890775b384ba1e4b0a7f2e1fb1
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/arm64-v8a/libLive2DCubismCore.so.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/arm64-v8a/libLive2DCubismCore.so.meta
@@ -1,0 +1,73 @@
+fileFormatVersion: 2
+guid: 476e10eb81162a047967ee81a6e38bcd
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude OpenHarmony: 0
+        Exclude WebGL: 1
+        Exclude WeixinMiniGame: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      OpenHarmony: OpenHarmony
+    second:
+      enabled: 1
+      settings:
+        CPU: ARM64
+        OpenHarmonySharedLibraryType: Executable
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/armeabi-v7a.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/armeabi-v7a.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 3ceec7dfce29fa648992f6a4cc1000b4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/armeabi-v7a/libLive2DCubismCore.so.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/armeabi-v7a/libLive2DCubismCore.so.meta
@@ -1,0 +1,73 @@
+fileFormatVersion: 2
+guid: dd1e3920198a128468ae2061ee93aa0d
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude OpenHarmony: 0
+        Exclude WebGL: 1
+        Exclude WeixinMiniGame: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      OpenHarmony: OpenHarmony
+    second:
+      enabled: 1
+      settings:
+        CPU: ARMv7
+        OpenHarmonySharedLibraryType: Executable
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/x86_64.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/x86_64.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc3b8ed364719594aa3536d72af2faa2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/HarmonyOS/x86_64/libLive2DCubismCore.so.meta
+++ b/Assets/Live2D/Cubism/Plugins/HarmonyOS/x86_64/libLive2DCubismCore.so.meta
@@ -1,0 +1,73 @@
+fileFormatVersion: 2
+guid: 7bbd39b9c76659948aa8b7606992ed67
+PluginImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  iconMap: {}
+  executionOrder: {}
+  defineConstraints: []
+  isPreloaded: 0
+  isOverridable: 0
+  isExplicitlyReferenced: 0
+  validateReferences: 1
+  platformData:
+  - first:
+      : Any
+    second:
+      enabled: 0
+      settings:
+        Exclude Editor: 1
+        Exclude Linux64: 1
+        Exclude OSXUniversal: 1
+        Exclude OpenHarmony: 0
+        Exclude WebGL: 1
+        Exclude WeixinMiniGame: 1
+        Exclude Win: 1
+        Exclude Win64: 1
+  - first:
+      Any: 
+    second:
+      enabled: 0
+      settings: {}
+  - first:
+      Editor: Editor
+    second:
+      enabled: 0
+      settings:
+        CPU: AnyCPU
+        DefaultValueInitialized: true
+        OS: AnyOS
+  - first:
+      OpenHarmony: OpenHarmony
+    second:
+      enabled: 1
+      settings:
+        CPU: X86_64
+        OpenHarmonySharedLibraryType: Executable
+  - first:
+      Standalone: Linux64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: OSXUniversal
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  - first:
+      Standalone: Win64
+    second:
+      enabled: 0
+      settings:
+        CPU: None
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Live2D/Cubism/Plugins/README.ja.md
+++ b/Assets/Live2D/Cubism/Plugins/README.ja.md
@@ -17,6 +17,9 @@
 | Android | x86 | Android/x86 |   |
 | Android | x86_64 | Android/x86_64 |   |
 | Emscripten |  | Experimental/Emscripten/latest | bitcode（upstream LLVM wasmバックエンド） |
+| HarmonyOS | ARM64 | HarmonyOS/arm64-v8a |   |
+| HarmonyOS | ARMv7 | HarmonyOS/armeabi-v7a |  |
+| HarmonyOS | x86_64 | HarmonyOS/x86_64 |   |
 | iOS | ARM64 | iOS/xxx-iphoneos | iOSデバイス |
 | iOS | x86_64 | iOS/xxx-iphonesimulator | iOS Simulator |
 | Linux | x86_64 | Linux/x86_64 |   |

--- a/Assets/Live2D/Cubism/Plugins/README.md
+++ b/Assets/Live2D/Cubism/Plugins/README.md
@@ -17,6 +17,9 @@ This folder contains platform-specific library files.
 | Android | x86 | Android/x86 |   |
 | Android | x86_64 | Android/x86_64 |   |
 | Emscripten |  | Experimental/Emscripten/latest | bitcode(upstream LLVM wasm backend) |
+| HarmonyOS | ARM64 | HarmonyOS/arm64-v8a |   |
+| HarmonyOS | ARMv7 | HarmonyOS/armeabi-v7a |  |
+| HarmonyOS | x86_64 | HarmonyOS/x86_64 |   |
 | iOS | ARM64 | iOS/xxx-iphoneos | iOS Devices |
 | iOS | x86_64 | iOS/xxx-iphonesimulator | iOS Simulator |
 | Linux | x86_64 | Linux/x86_64 |   |

--- a/Assets/Live2D/Cubism/Plugins/RedistributableFiles.txt
+++ b/Assets/Live2D/Cubism/Plugins/RedistributableFiles.txt
@@ -10,6 +10,9 @@ under the terms of the Live2D Proprietary Software License Agreement:
 - Experimental/UWP/arm64/Live2DCubismCore.dll
 - Experimental/UWP/x64/Live2DCubismCore.dll
 - Experimental/UWP/x86/Live2DCubismCore.dll
+- HarmonyOS/arm64-v8a/libLive2DCubismCore.so
+- HarmonyOS/armeabi-v7a/libLive2DCubismCore.so
+- HarmonyOS/x86_64/libLive2DCubismCore.so
 - iOS/Debug-iphoneos/libLive2DCubismCore.a
 - iOS/Debug-iphonesimulator/libLive2DCubismCore.a
 - iOS/Release-iphoneos/libLive2DCubismCore.a

--- a/Assets/Live2D/Cubism/README.ja.md
+++ b/Assets/Live2D/Cubism/README.ja.md
@@ -69,6 +69,13 @@ Unity Editor拡張機能は、`./Assets/Live2D/Cubism/Editor`にあります。
 
 *2 Unityに組み込まれたライブラリまたは推奨ライブラリを使用してください。
 
+| HarmonyOS NEXT 対応ツール | バージョン |
+| --- | --- |
+| Tuanjie | 1.0.1 |
+| DevEco Studio *3 | 4.0 |
+
+*3 中国国外でのHarmonyOS NEXT向けビルドはDevEcoを通じてビルドする必要があります。
+
 ### C#コンパイラ
 
 Unity2018.4以降でサポートされているRoslynまたはmcsコンパイラを使用してビルドします。
@@ -92,6 +99,7 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Google Chrome | 122.0.6261.129 |
 | Chrome OS 64bit (x86_64) | 122.0.6261.118 |
 | Chrome OS 32bit (ARMv8) (*3) | 122.0.6261.118 |
+| HarmonyOS NEXT | 4.0.0.66 |
 
 *3 Android向けAPKファイルでの動作確認です。
 

--- a/Assets/Live2D/Cubism/README.md
+++ b/Assets/Live2D/Cubism/README.md
@@ -70,6 +70,13 @@ Resources like shaders and other assets are located in `./Assets/Live2D/Cubism/R
 
 *2 Use libraries embedded with Unity or recommended.
 
+| HarmonyOS NEXT Supported Tools | Version |
+| --- | --- |
+| Tuanjie | 1.0.1 |
+| DevEco Studio *3 | 4.0 |
+
+*3 Builds for HarmonyOS NEXT outside of China must be built through DevEco.
+
 ### C# compiler
 
 Build using Roslyn or mcs compiler supported by Unity 2018.4 and above.
@@ -93,6 +100,7 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Google Chrome | 122.0.6261.129 |
 | Chrome OS 64bit (x86_64) | 122.0.6261.118 |
 | Chrome OS 32bit (ARMv8) (*3) | 122.0.6261.118 |
+| HarmonyOS NEXT | 4.0.0.66 |
 
 *3 This is a confirmation of operation with APK files for Android.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,16 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [5-r.2] - 2024-04-04
+
+### Added
+
+* Add HarmonyOS NEXT from the tested environment.
+
+### Fixed
+
+* Fix an issue where the `Allow 'unsafe' Code` property was not enabled in the `Live2D.Cubism.asmdef`.
+
 
 ## [5-r.1] - 2024-03-26
 
@@ -396,6 +406,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 * Fix issue where Priority value was not reset after playing motion with CubismMotionController.
 
 
+[5-r.2]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1...5-r.2
 [5-r.1]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.4...5-r.1
 [5-r.1-beta.4]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.3...5-r.1-beta.4
 [5-r.1-beta.3]: https://github.com/Live2D/CubismUnityComponents/compare/5-r.1-beta.2...5-r.1-beta.3

--- a/README.ja.md
+++ b/README.ja.md
@@ -69,6 +69,13 @@ Unity Editor拡張機能は、`./Assets/Live2D/Cubism/Editor`にあります。
 
 *2 Unityに組み込まれたライブラリまたは推奨ライブラリを使用してください。
 
+| HarmonyOS NEXT 対応ツール | バージョン |
+| --- | --- |
+| Tuanjie | 1.0.1 |
+| DevEco Studio *3 | 4.0 |
+
+*3 中国国外でのHarmonyOS NEXT向けビルドはDevEcoを通じてビルドする必要があります。
+
 ### C#コンパイラ
 
 Unity2018.4以降でサポートされているRoslynまたはmcsコンパイラを使用してビルドします。
@@ -92,6 +99,7 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Google Chrome | 122.0.6261.129 |
 | Chrome OS 64bit (x86_64) | 122.0.6261.118 |
 | Chrome OS 32bit (ARMv8) (*3) | 122.0.6261.118 |
+| HarmonyOS NEXT | 4.0.0.66 |
 
 *3 Android向けAPKファイルでの動作確認です。
 

--- a/README.md
+++ b/README.md
@@ -70,6 +70,13 @@ Resources like shaders and other assets are located in `./Assets/Live2D/Cubism/R
 
 *2 Use libraries embedded with Unity or recommended.
 
+| HarmonyOS NEXT Supported Tools | Version |
+| --- | --- |
+| Tuanjie | 1.0.1 |
+| DevEco Studio *3 | 4.0 |
+
+*3 Builds for HarmonyOS NEXT outside of China must be built through DevEco.
+
 ### C# compiler
 
 Build using Roslyn or mcs compiler supported by Unity 2018.4 and above.
@@ -93,6 +100,7 @@ https://docs.unity3d.com/ja/2018.4/Manual/CSharpCompiler.html
 | Google Chrome | 122.0.6261.129 |
 | Chrome OS 64bit (x86_64) | 122.0.6261.118 |
 | Chrome OS 32bit (ARMv8) (*3) | 122.0.6261.118 |
+| HarmonyOS NEXT | 4.0.0.66 |
 
 *3 This is a confirmation of operation with APK files for Android.
 


### PR DESCRIPTION
### Added

* Add HarmonyOS NEXT from the tested environment.

### Fixed

* Fix an issue where the `Allow 'unsafe' Code` property was not enabled in the `Live2D.Cubism.asmdef`.