### PR TITLE
Skip patching .csproj files when assembly definitions are available

### DIFF
--- a/Assets/Live2D/Cubism/Editor/CubismAssetProcessor.cs
+++ b/Assets/Live2D/Cubism/Editor/CubismAssetProcessor.cs
@@ -28,6 +28,7 @@ namespace Live2D.Cubism.Editor
     {
         #region Unity Event Handling
 
+#if !UNITY_2017_3_OR_NEWER
         /// <summary>
         /// Called by Unity. Makes sure <see langword="unsafe"/> code is allowed.
         /// </summary>
@@ -36,6 +37,7 @@ namespace Live2D.Cubism.Editor
         {
             AllowUnsafeCode();
         }
+#endif
 
 
         /// <summary>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
+## [Unreleased] - ####-##-##
+
+### Changed
+
+- Change `OnGeneratedCSProjectFiles` function to be disabled in Unity 2017.3 and later by [@moz-moz](https://github.com/moz-moz)
+
+
 ## [5-r.2] - 2024-04-04
 
 ### Added


### PR DESCRIPTION
## Changes
For Unity versions 2017.3 and later, which support Assembly Definitions,
the CubismAssetProcessor will skip patching the `.csproj` files.

## Motivation
Since unsafe code is allowed through `csc.rsp`, `mcs.rsp`, and `Live2D.Cubism.asmdef` files,
it is now safe to stop adding or modifying the `AllowUnsafeBlocks` setting in `.csproj` files.

Furthermore, the JetBrains Rider IDE does not support the `OnGeneratedCSProjectFiles` method and issues a warning when this method is defined.

With this change, users will be freed from unnecessary processing costs and the effort required to ignore such warnings.