### PR TITLE
Drawableの透明度等の設定が反映されないことがあるバグを修正

### DIFF
--- a/Assets/Live2D/Cubism/Core/ArrayExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Core/ArrayExtensionMethods.cs
@@ -220,7 +220,8 @@ namespace Live2D.Cubism.Core
         /// </summary>
         /// <param name="self">Buffer to write to.</param>
         /// <param name="unmanagedModel">Unmanaged model to read from.</param>
-        internal static unsafe void ReadFrom(this CubismDynamicDrawableData[] self, CubismUnmanagedModel unmanagedModel)
+        /// <param name="force">force DidChange</param>
+        internal static unsafe void ReadFrom(this CubismDynamicDrawableData[] self, CubismUnmanagedModel unmanagedModel, bool force)
         {
             // Get addresses.
             var drawables = unmanagedModel.Drawables;
@@ -238,7 +239,8 @@ namespace Live2D.Cubism.Core
                 var data = self[i];
 
 
-                data.Flags = flags[i];
+                var newFlags = force ? (byte)(data.Flags.MaskDidChangeFlag() | flags[i]) : flags[i];
+                data.Flags = newFlags;
                 data.Opacity = opacities[i];
                 data.DrawOrder = drawOrders[i];
                 data.RenderOrder = renderOrders[i];

--- a/Assets/Live2D/Cubism/Core/CubismDynamicDrawableData.cs
+++ b/Assets/Live2D/Cubism/Core/CubismDynamicDrawableData.cs
@@ -51,7 +51,7 @@ namespace Live2D.Cubism.Core
         /// <summary>
         /// Dirty flags.
         /// </summary>
-        internal byte Flags { private get; set; }
+        internal byte Flags { get; set; }
 
 
         /// <summary>

--- a/Assets/Live2D/Cubism/Core/CubismTaskableModel.cs
+++ b/Assets/Live2D/Cubism/Core/CubismTaskableModel.cs
@@ -266,7 +266,7 @@ namespace Live2D.Cubism.Core
 
 
             // Run execution directly.
-            Execute();
+            Execute(true);
 
 
             return true;
@@ -301,7 +301,7 @@ namespace Live2D.Cubism.Core
         /// <summary>
         /// Runs the task.
         /// </summary>
-        private void Execute()
+        private void Execute(bool force)
         {
             // Validate state.
             lock (Lock)
@@ -315,7 +315,7 @@ namespace Live2D.Cubism.Core
 
 
             // Get results.
-            DynamicDrawableData.ReadFrom(UnmanagedModel);
+            DynamicDrawableData.ReadFrom(UnmanagedModel, force);
 
 
             // Update state.
@@ -349,7 +349,7 @@ namespace Live2D.Cubism.Core
 
         void ICubismTask.Execute()
         {
-            Execute();
+            Execute(false);
         }
 
         #endregion

--- a/Assets/Live2D/Cubism/Core/Unmanaged/ByteExtensionMethods.cs
+++ b/Assets/Live2D/Cubism/Core/Unmanaged/ByteExtensionMethods.cs
@@ -125,5 +125,15 @@ namespace Live2D.Cubism.Core.Unmanaged
             return (self & (1 << 6)) == (1 << 6);
         }
 
+        /// <summary>
+        /// Mask DidChageFlag. without IsVisivble flag.
+        /// </summary>
+        /// <param name="self"></param>
+        /// <returns></returns>
+        public static byte MaskDidChangeFlag(this byte self)
+        {
+            return (byte)(self & ~(1 << 0));
+        }
+
     }
 }


### PR DESCRIPTION
CubismDynamicDrawableData.Flags で透明度等のフラグが変更されるフレームと
CubismModel.enabled が false になるフレームが同一フレームとなる場合、
CubismRenderController.OnDynamicDrawableData が呼ばれないため、Flags の消化がされない状態になる。

その後 CubismModel.enabled が true になると CubismRenderController.OnDynamicDrawableData の前に
CubismDynamicDrawableData.Flags が更新されてしまうためフラグの消化が漏れるケースがあった。

今回の修正は CubismModel.enabled が true になったフレームで未消化のフラグと or をとることでフラグが消化されるようにした。