### PR TITLE
Avoid per-frame delegate allocation in render-data lookups

### DIFF
--- a/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
+++ b/Assets/Live2D/Cubism/Rendering/CubismRenderController.cs
@@ -909,6 +909,19 @@ namespace Live2D.Cubism.Rendering
             }
         }
 
+        private static int IndexOfDrawable(CubismRenderer[] renderers, int unmanagedIndex)
+        {
+            for (var i = 0; i < renderers.Length; i++)
+            {
+                if (renderers[i].Drawable.UnmanagedIndex == unmanagedIndex)
+                {
+                    return i;
+                }
+            }
+
+            return -1;
+        }
+
         /// <summary>
         /// Called whenever new render data is available.
         /// </summary>
@@ -924,7 +937,7 @@ namespace Live2D.Cubism.Rendering
             // Handle render data changes.
             for (var dataIndex = 0; dataIndex < data.Length; ++dataIndex)
             {
-                var rendererIndex = Array.FindIndex(renderers, cubismRenderer => cubismRenderer.Drawable.UnmanagedIndex == dataIndex);
+                var rendererIndex = IndexOfDrawable(renderers, dataIndex);
 
                 // Skip if no renderer found.
                 if (rendererIndex < 0) {
@@ -1018,7 +1031,7 @@ namespace Live2D.Cubism.Rendering
 
             for (var dataIndex = 0; dataIndex < data.Length; ++dataIndex)
             {
-                var rendererIndex = Array.FindIndex(renderers, cubismRenderer => cubismRenderer.Drawable.UnmanagedIndex == dataIndex);
+                var rendererIndex = IndexOfDrawable(renderers, dataIndex);
 
                 // Skip if no renderer found.
                 if (rendererIndex < 0)
@@ -1041,7 +1054,7 @@ namespace Live2D.Cubism.Rendering
 
             for (var dataIndex = 0; dataIndex < data.Length; ++dataIndex)
             {
-                var rendererIndex = Array.FindIndex(renderers, cubismRenderer => cubismRenderer.Drawable.UnmanagedIndex == dataIndex);
+                var rendererIndex = IndexOfDrawable(renderers, dataIndex);
 
                 // Skip if no renderer found.
                 if (rendererIndex < 0)

--- a/Assets/Live2D/Cubism/Rendering/URP/RenderingInterceptor/CubismRenderingInterceptController.cs
+++ b/Assets/Live2D/Cubism/Rendering/URP/RenderingInterceptor/CubismRenderingInterceptController.cs
@@ -269,7 +269,15 @@ namespace Live2D.Cubism.Rendering.URP.RenderingInterceptor
             var currentCamera = args.PassData.CameraData.camera;
 
             // Find or create camera draw status.
-            var statusIndex = Array.FindIndex(_cameraDrawStatus, status => status.Camera == currentCamera);
+            var statusIndex = -1;
+            for (var i = 0; i < _cameraDrawStatus.Length; i++)
+            {
+                if (_cameraDrawStatus[i].Camera == currentCamera)
+                {
+                    statusIndex = i;
+                    break;
+                }
+            }
 
             // Create a new entry if not found.
             if (statusIndex < 0)


### PR DESCRIPTION
## Summary

Replaces capturing-lambda `Array.FindIndex` calls on the per-frame render path with allocation-free `for` loops, removing a `Predicate<T>` delegate allocation on every call. No behavior change.

## Problem

`CubismRenderController.OnDynamicDrawableData` — invoked from `CubismModel.Update()` every frame — locates the renderer for each drawable with:

```csharp
var rendererIndex = Array.FindIndex(renderers, cubismRenderer => cubismRenderer.Drawable.UnmanagedIndex == dataIndex);
```

It runs in three loops over all drawables, once per drawable *before* any dirty check — `3 × drawableCount` times per frame. The lambda captures the loop variable `dataIndex`, so the compiler cannot cache it as a static delegate (only *non-capturing* lambdas are cached); a `Predicate<T>` is allocated on every call. `CubismRenderingInterceptController.TryDraw` has the same pattern, capturing `currentCamera`.

## Changes

- `OnDynamicDrawableData`: the three loops share one allocation-free `IndexOfDrawable` helper (a plain `for` loop) instead of the capturing `Array.FindIndex`.
- `TryDraw`: the capturing `Array.FindIndex` over `_cameraDrawStatus` is inlined as a `for` loop.

## Why this is safe

Functionally identical to `Array.FindIndex`: it returns the first index whose `Drawable.UnmanagedIndex` matches `dataIndex` (or the first entry whose `Camera` matches, for `TryDraw`), or `-1` when none matches; the existing `< 0` handling is unchanged. The lookup is still resolved by `Drawable.UnmanagedIndex` exactly as before. No public API or behavior change.
